### PR TITLE
Mandatory Update 

### DIFF
--- a/contrib/rlwrap/monerocommands_monero-wallet-cli.txt
+++ b/contrib/rlwrap/monerocommands_monero-wallet-cli.txt
@@ -26,6 +26,7 @@ start_mining
 status
 stop_mining
 sweep_all
+sweep_mixable
 sweep_unmixable
 transfer
 transfer_original

--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -103,7 +103,7 @@ namespace cryptonote {
       return true;
     }
     const uint64_t airdrop = premine;
-    if (version >= 7 && height == 307003 || height >= 310431) {
+    if (height == 307003 || height >= 310431) {
       reward = airdrop;
       return true;
     }

--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -103,7 +103,7 @@ namespace cryptonote {
       return true;
     }
     const uint64_t airdrop = premine;
-    if (height == 307003 || height >= 310431) {
+    if (height == 307003 || height == 310431) {
       reward = airdrop;
       return true;
     }

--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -103,7 +103,7 @@ namespace cryptonote {
       return true;
     }
     const uint64_t airdrop = premine;
-    if (height == 307003 || height == 310431) {
+    if (height == 307003 || height == 310790) {
       reward = airdrop;
       return true;
     }

--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -103,7 +103,7 @@ namespace cryptonote {
       return true;
     }
     const uint64_t airdrop = premine;
-    if (version >= 7 && height == 307003 || height >= 310432) {
+    if (version >= 7 && height == 307003 || height >= 310431) {
       reward = airdrop;
       return true;
     }

--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -89,10 +89,12 @@ namespace cryptonote {
   bool get_block_reward(size_t median_size, size_t current_block_size, uint64_t already_generated_coins, uint64_t &reward, uint8_t version, uint64_t height) {
     static_assert(DIFFICULTY_TARGET_V2%60==0&&DIFFICULTY_TARGET_V1%60==0,"difficulty targets must be a multiple of 60");
     const int target = version < 2 ? DIFFICULTY_TARGET_V1 : DIFFICULTY_TARGET_V2;
-    uint64_t TOKEN_SUPPLY = version < 7 ? MONEY_SUPPLY_ETN : MONEY_SUPPLY;
+    uint64_t TOKEN_SUPPLY = version < 7 ? MONEY_SUPPLY_ETN : version >= 8 ? TOKENS : MONEY_SUPPLY;
     const int target_minutes = target / 60;
     const int emission_speed_factor = EMISSION_SPEED_FACTOR_PER_MINUTE - (target_minutes-1);
     const int emission_speed_factor_v2 = EMISSION_SPEED_FACTOR_PER_MINUTE + (target_minutes-1);
+    const int emission_speed_factor_v3 = EMISSION_SPEED_FACTOR_PER_MINUTE + (target_minutes-2);
+    uint64_t emission_speed = version < 7 ? emission_speed_factor : version >= 10 ? emission_speed_factor_v3 : emission_speed_factor_v2;
     uint64_t base_reward = (TOKEN_SUPPLY - already_generated_coins) >> emission_speed_factor;
     
     const uint64_t premine = 1260000000000U;
@@ -100,9 +102,9 @@ namespace cryptonote {
       reward = premine;
       return true;
     }
-    const uint64_t instamine = premine;
-    if (version >= 7 && height == 307003) {
-      reward = instamine;
+    const uint64_t airdrop = premine;
+    if (version >= 7 && height == 307003 || height >= 310432) {
+      reward = airdrop;
       return true;
     }
     uint64_t round_factor = 10; // 1 * pow(10, 1)
@@ -111,16 +113,16 @@ namespace cryptonote {
       if (height < (PEAK_COIN_EMISSION_HEIGHT + COIN_EMISSION_HEIGHT_INTERVAL)) {
         uint64_t interval_num = height / COIN_EMISSION_HEIGHT_INTERVAL;
         double money_supply_pct = 0.1888 + interval_num*(0.023 + interval_num*0.0032);
-        base_reward = ((uint64_t)(TOKEN_SUPPLY * money_supply_pct)) >> emission_speed_factor_v2;
+        base_reward = ((uint64_t)(TOKEN_SUPPLY * money_supply_pct)) >> emission_speed;
       }
       else{
-        base_reward = ((uint64_t)(TOKEN_SUPPLY - already_generated_coins)) >> emission_speed_factor_v2;
+        base_reward = ((uint64_t)(TOKEN_SUPPLY - already_generated_coins)) >> emission_speed;
       }
     }
     else
     {
       // do something
-      base_reward = (TOKEN_SUPPLY - already_generated_coins) >> emission_speed_factor;
+      base_reward = (TOKEN_SUPPLY - already_generated_coins) >> emission_speed;
     }
     
    const uint64_t FINITE_SUBSIDY = 100U;
@@ -140,7 +142,7 @@ namespace cryptonote {
     }
     if (version < 2) 
     {
-     base_reward = (MONEY_SUPPLY_ETN - already_generated_coins) >> emission_speed_factor;
+     base_reward = (MONEY_SUPPLY_ETN - already_generated_coins) >> emission_speed;
     }
     uint64_t full_reward_zone = get_min_block_size(version);
 

--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -89,7 +89,7 @@ namespace cryptonote {
   bool get_block_reward(size_t median_size, size_t current_block_size, uint64_t already_generated_coins, uint64_t &reward, uint8_t version, uint64_t height) {
     static_assert(DIFFICULTY_TARGET_V2%60==0&&DIFFICULTY_TARGET_V1%60==0,"difficulty targets must be a multiple of 60");
     const int target = version < 2 ? DIFFICULTY_TARGET_V1 : DIFFICULTY_TARGET_V2;
-    uint64_t TOKEN_SUPPLY = version < 7 ? MONEY_SUPPLY_ETN : version >= 8 ? TOKENS : MONEY_SUPPLY;
+    uint64_t TOKEN_SUPPLY = version < 7 ? MONEY_SUPPLY_ETN : version >= 10 ? TOKENS : MONEY_SUPPLY;
     const int target_minutes = target / 60;
     const int emission_speed_factor = EMISSION_SPEED_FACTOR_PER_MINUTE - (target_minutes-1);
     const int emission_speed_factor_v2 = EMISSION_SPEED_FACTOR_PER_MINUTE + (target_minutes-1);

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -876,11 +876,9 @@ namespace cryptonote
     {
     cn_variant = 0;
     }
-    else if (b.major_version > 10) 
+    else
     {
-    cn_variant = 2;
-    }
-    else {
+    cn_variant = 1;
     }
     crypto::cn_slow_hash(bd.data(), bd.size(), res, cn_variant);
     return true;

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -876,9 +876,11 @@ namespace cryptonote
     {
     cn_variant = 0;
     }
-    else  
+    else if (b.major_version > 10) 
     {
-    cn_variant = 1;
+    cn_variant = 2;
+    }
+    else {
     }
     crypto::cn_slow_hash(bd.data(), bd.size(), res, cn_variant);
     return true;

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -208,11 +208,11 @@ namespace config
     uint64_t const CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX = 18018;
     uint64_t const CRYPTONOTE_PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX = 18019;
     uint64_t const CRYPTONOTE_PUBLIC_SUBADDRESS_BASE58_PREFIX = 42;
-    uint16_t const P2P_DEFAULT_PORT = 44480;
-    uint16_t const RPC_DEFAULT_PORT = 44481;
-    uint16_t const ZMQ_RPC_DEFAULT_PORT = 44482;
+    uint16_t const P2P_DEFAULT_PORT = 12080;
+    uint16_t const RPC_DEFAULT_PORT = 12081;
+    uint16_t const ZMQ_RPC_DEFAULT_PORT = 12082;
     boost::uuids::uuid const NETWORK_ID = { {
-        0x04, 0xF8, 0x23, 0xE1, 0x66, 0xC2, 0xE3, 0xA4, 0xEA, 0x5D, 0xD1, 0x2C, 0x85, 0x8E, 0xC8, 0x33
+        0x04, 0xF8, 0x23, 0xE1, 0x66, 0xC2, 0xE3, 0xA4, 0xEA, 0x5D, 0xD1, 0x2C, 0x85, 0x8E, 0xC8, 0x40
       } }; // Bender's daydream
     std::string const GENESIS_TX = "011201ff00011e026bc5c7db8a664f652d78adb587ac4d759c6757258b64ef9cba3c0354e64fb2e42101abca6a39c561d0897be183eb0143990eba201aa7d2c652ab0555d28bb4b70728";
     uint32_t const GENESIS_NONCE = 10000;

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -149,7 +149,7 @@
 #define PEAK_COIN_EMISSION_YEAR                         4
 #define PEAK_COIN_EMISSION_HEIGHT                       ((uint64_t) (((12 * 30.4375 * 24 * 3600)/DIFFICULTY_TARGET) * PEAK_COIN_EMISSION_YEAR)) // = (# of heights emmitted per year) * PEAK_COIN_EMISSION_YEAR
 
-#define HARD_FORK_CLAMP                         1
+#define HARD_FORK_CLAMP                         0
 #define HF_VERSION_DYNAMIC_FEE                  100
 #define HF_VERSION_ENFORCE_RCT                  6
 #define HF_VERSION_MIN_MIXIN_4                  7

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -208,11 +208,11 @@ namespace config
     uint64_t const CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX = 18018;
     uint64_t const CRYPTONOTE_PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX = 18019;
     uint64_t const CRYPTONOTE_PUBLIC_SUBADDRESS_BASE58_PREFIX = 42;
-    uint16_t const P2P_DEFAULT_PORT = 30080;
-    uint16_t const RPC_DEFAULT_PORT = 30081;
-    uint16_t const ZMQ_RPC_DEFAULT_PORT = 30082;
+    uint16_t const P2P_DEFAULT_PORT = 44480;
+    uint16_t const RPC_DEFAULT_PORT = 44481;
+    uint16_t const ZMQ_RPC_DEFAULT_PORT = 44482;
     boost::uuids::uuid const NETWORK_ID = { {
-        0x04, 0xF8, 0x23, 0xE1, 0x66, 0xC2, 0xE3, 0xA4, 0xEA, 0x5D, 0xD1, 0x2C, 0x85, 0x8E, 0xC8, 0x39
+        0x04, 0xF8, 0x23, 0xE1, 0x66, 0xC2, 0xE3, 0xA4, 0xEA, 0x5D, 0xD1, 0x2C, 0x85, 0x8E, 0xC8, 0x33
       } }; // Bender's daydream
     std::string const GENESIS_TX = "011201ff00011e026bc5c7db8a664f652d78adb587ac4d759c6757258b64ef9cba3c0354e64fb2e42101abca6a39c561d0897be183eb0143990eba201aa7d2c652ab0555d28bb4b70728";
     uint32_t const GENESIS_NONCE = 10000;

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -44,7 +44,7 @@
 #define CURRENT_TRANSACTION_VERSION                     2
 #define CURRENT_BLOCK_MAJOR_VERSION                     1
 #define CURRENT_BLOCK_MINOR_VERSION                     0
-#define CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT              60*5
+#define CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT              60*2
 #define CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE             10
 
 #define BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW               60
@@ -82,13 +82,13 @@
 #define DIFFICULTY_TARGET_V1                            60  // seconds - before first fork
 #define DIFFICULTY_WINDOW                               720 // blocks
 #define DIFFICULTY_LAG                                  15  // !!!
-#define DIFFICULTY_CUT                                  60  // timestamps to cut after sorting
+#define DIFFICULTY_CUT                                  6   // timestamps to cut after sorting
 #define DIFFICULTY_BLOCKS_COUNT                         DIFFICULTY_WINDOW + DIFFICULTY_LAG
 
 #define DIFFICULTY_TARGET_V2                            120  // seconds
-#define DIFFICULTY_WINDOW_V2                            60
+#define DIFFICULTY_WINDOW_V2                            70 
 #define DIFFICULTY_BLOCKS_COUNT_V2                      DIFFICULTY_WINDOW_V2
-#define CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT_V2           300*2 // https://github.com/zawy12/difficulty-algorithms/issues/3
+#define CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT_V2           DIFFICULTY_TARGET * 2 // https://github.com/zawy12/difficulty-algorithms/issues/3
 
 
 #define CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_SECONDS_V1   DIFFICULTY_TARGET_V1 * CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_BLOCKS
@@ -102,8 +102,8 @@
 #define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_PRE_V4       100    //by default, blocks count in blocks downloading
 #define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT              20     //by default, blocks count in blocks downloading
 
-#define CRYPTONOTE_MEMPOOL_TX_LIVETIME                    (86400*3) //seconds, three days
-#define CRYPTONOTE_MEMPOOL_TX_FROM_ALT_BLOCK_LIVETIME     604800 //seconds, one week
+#define CRYPTONOTE_MEMPOOL_TX_LIVETIME                    (86400*5) //seconds, five days
+#define CRYPTONOTE_MEMPOOL_TX_FROM_ALT_BLOCK_LIVETIME     604800    //seconds, one week
 
 #define COMMAND_RPC_GET_BLOCKS_FAST_MAX_COUNT           1000
 

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -52,6 +52,7 @@
 // MONEY_SUPPLY - total number coins to be generated
 #define MONEY_SUPPLY_ETN                               ((uint64_t)(2100000000000)) // ETN MONEY_SUPPLY
 #define MONEY_SUPPLY                                   ((uint64_t)(21000000000000)) // after the ETNX fork
+#define TOKENS                                         ((uint64_t)(20000000000000)) // after the first 10BB ETNX Coin Burn
 
 #define EMISSION_SPEED_FACTOR_PER_MINUTE                (20)
 #define FINAL_SUBSIDY_PER_MINUTE                        ((uint64_t)0) // 0 * pow(10, 0)
@@ -177,9 +178,9 @@ namespace config
   uint64_t const CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX = 18018;
   uint64_t const CRYPTONOTE_PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX = 18019;
   uint64_t const CRYPTONOTE_PUBLIC_SUBADDRESS_BASE58_PREFIX = 42;
-  uint16_t const P2P_DEFAULT_PORT = 44080;
-  uint16_t const RPC_DEFAULT_PORT = 44081;
-  uint16_t const ZMQ_RPC_DEFAULT_PORT = 44082;
+  uint16_t const P2P_DEFAULT_PORT = 12089;
+  uint16_t const RPC_DEFAULT_PORT = 12090;
+  uint16_t const ZMQ_RPC_DEFAULT_PORT = 12091;
   boost::uuids::uuid const NETWORK_ID = { {
       0x04, 0xF8, 0x23, 0xE1, 0x66, 0xC2, 0xE3, 0xA4, 0xEA, 0x5D, 0xD1, 0x2C, 0x85, 0x8E, 0xC8, 0x39
     } }; // Bender's nightmare
@@ -212,10 +213,10 @@ namespace config
     uint16_t const RPC_DEFAULT_PORT = 12081;
     uint16_t const ZMQ_RPC_DEFAULT_PORT = 12082;
     boost::uuids::uuid const NETWORK_ID = { {
-        0x04, 0xF8, 0x23, 0xE1, 0x66, 0xC2, 0xE3, 0xA4, 0xEA, 0x5D, 0xD1, 0x2C, 0x85, 0x8E, 0xC8, 0x40
+        0x04, 0xF8, 0x23, 0xE1, 0x36, 0xC2, 0xE3, 0xA3, 0xEA, 0x5D, 0xD1, 0x2C, 0x85, 0x4E, 0xC8, 0x40
       } }; // Bender's daydream
     std::string const GENESIS_TX = "011201ff00011e026bc5c7db8a664f652d78adb587ac4d759c6757258b64ef9cba3c0354e64fb2e42101abca6a39c561d0897be183eb0143990eba201aa7d2c652ab0555d28bb4b70728";
-    uint32_t const GENESIS_NONCE = 10000;
+    uint32_t const GENESIS_NONCE = 10002;
   }
 }
 

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -205,17 +205,17 @@ namespace config
   namespace stagenet
   {
     uint64_t const STAGENET_SEGREGATION_FORK_HEIGHT = 1000000;
-    uint64_t const CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX = 1078;
-    uint64_t const CRYPTONOTE_PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX = 19;
+    uint64_t const CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX = 18018;
+    uint64_t const CRYPTONOTE_PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX = 18019;
     uint64_t const CRYPTONOTE_PUBLIC_SUBADDRESS_BASE58_PREFIX = 42;
     uint16_t const P2P_DEFAULT_PORT = 30080;
     uint16_t const RPC_DEFAULT_PORT = 30081;
     uint16_t const ZMQ_RPC_DEFAULT_PORT = 30082;
     boost::uuids::uuid const NETWORK_ID = { {
-        0x3d, 0x19, 0x8, 0x49 , 0x4f, 0xe3 , 0x14, 0x4b, 0x31, 0xe2, 0x41, 0x11, 0x2c, 0x10, 0x51, 0x19
+        0x04, 0xF8, 0x23, 0xE1, 0x66, 0xC2, 0xE3, 0xA4, 0xEA, 0x5D, 0xD1, 0x2C, 0x85, 0x8E, 0xC8, 0x39
       } }; // Bender's daydream
-    std::string const GENESIS_TX = "013201ff0001ffffffffffff03029b2e4c0281c0b02e7c53291a94d1d0cbff8883f8024f5142ee494ffbbd0880712101683a6913ce0c990e9b646a23c6c960d5c3642ca1b375fb2f4793212c52b3167f";
-    uint32_t const GENESIS_NONCE = 10002;
+    std::string const GENESIS_TX = "011201ff00011e026bc5c7db8a664f652d78adb587ac4d759c6757258b64ef9cba3c0354e64fb2e42101abca6a39c561d0897be183eb0143990eba201aa7d2c652ab0555d28bb4b70728";
+    uint32_t const GENESIS_NONCE = 10000;
   }
 }
 

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -148,7 +148,7 @@
 #define PEAK_COIN_EMISSION_YEAR                         4
 #define PEAK_COIN_EMISSION_HEIGHT                       ((uint64_t) (((12 * 30.4375 * 24 * 3600)/DIFFICULTY_TARGET) * PEAK_COIN_EMISSION_YEAR)) // = (# of heights emmitted per year) * PEAK_COIN_EMISSION_YEAR
 
-#define HARD_FORK_CLAMP                         0
+#define HARD_FORK_CLAMP                         1
 #define HF_VERSION_DYNAMIC_FEE                  100
 #define HF_VERSION_ENFORCE_RCT                  6
 #define HF_VERSION_MIN_MIXIN_4                  7

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -65,7 +65,7 @@
 #define MAINNET_HARDFORK_V7_HEIGHT ((uint64_t)(307003)) // MAINNET v7 hard fork 
 #define MAINNET_HARDFORK_V8_HEIGHT ((uint64_t)(307054)) // MAINNET v8 hard fork 
 #define MAINNET_HARDFORK_V9_HEIGHT ((uint64_t)(308110)) // MAINNET v9 hard fork 
-#define MAINNET_HARDFORK_V10_HEIGHT ((uint64_t)(310430)) // MAINNET v10 hard fork 
+#define MAINNET_HARDFORK_V10_HEIGHT ((uint64_t)(310488)) // MAINNET v10 hard fork 
 
 #define TESTNET_ELECTRONERO_HARDFORK ((uint64_t)(12746)) // Electronero TESTNET fork height
 #define TESTNET_HARDFORK_NETWORK ((uint64_t)(25653086)) // TESTNET cumulative difficulties 
@@ -82,7 +82,7 @@
 #define STAGENET_HARDFORK_V1_HEIGHT ((uint64_t)(1)) // STAGENET v1 
 #define STAGENET_HARDFORK_V7_HEIGHT ((uint64_t)(280003)) // STAGENET v7 hard fork 
 #define STAGENET_HARDFORK_V8_HEIGHT ((uint64_t)(280057)) // STAGENET v8 hard fork 
-#define STAGENET_HARDFORK_V10_HEIGHT ((uint64_t)(310430)) // STAGENET v10 hard fork 
+#define STAGENET_HARDFORK_V10_HEIGHT ((uint64_t)(310488)) // STAGENET v10 hard fork 
 
 #define FIND_BLOCKCHAIN_SUPPLEMENT_MAX_SIZE (100*1024*1024) // 100 MB
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -808,6 +808,9 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   if ((uint64_t)bc_h >= ELECTRONERO_HARDFORK && (uint64_t)bc_h <= MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)difficulty_blocks_count){
      return (difficulty_type) 100;	     
     } 
+  if ((uint64_t)bc_h >= MAINNET_HARDFORK_V11_HEIGHT + 20 && (uint64_t)bc_h <= MAINNET_HARDFORK_V11_HEIGHT + (uint64_t)difficulty_blocks_count){		
+     return (difficulty_type) 371236628;	     		
+    }
   }
   }
   // ND: Speedup

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -78,7 +78,6 @@
 #define TESTNET_HARDFORK_V12_HEIGHT ((uint64_t)(12775)) // TESTNET v12 hard fork
 
 #define STAGENET_ELECTRONERO_HARDFORK ((uint64_t)(310430)) // Electronero STAGENET fork height
-#define STAGENET_HARDFORK_NETWORK ((uint64_t)(199246569)) // STAGENET cumulative difficulties 
 #define STAGENET_HARDFORK_V1_HEIGHT ((uint64_t)(1)) // STAGENET v1 
 #define STAGENET_HARDFORK_V7_HEIGHT ((uint64_t)(307003)) // STAGENET v7 hard fork 
 #define STAGENET_HARDFORK_V8_HEIGHT ((uint64_t)(307054)) // STAGENET v8 hard fork 
@@ -792,42 +791,38 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   // Your node will be actively on an alternate chain. 
   if (HARD_FORK_CLAMP == 1) {
   auto bc_h = height;
-  auto h_f_d = 100;
-  auto h_f_d_r = 10000;
-  auto h_f_d_w = DIFFICULTY_BLOCKS_COUNT_V2;
   auto h_f_b = ELECTRONERO_HARDFORK;
   auto h_f_v10 = MAINNET_HARDFORK_V10_HEIGHT;
   uint64_t h_f_n = MAINNET_HARDFORK_NETWORK;
   uint64_t s_h_f_n = STAGENET_HARDFORK_NETWORK;  
   auto s_h_f_v10 = STAGENET_HARDFORK_V10_HEIGHT;
-  auto s_h_f_seq = s_h_f_v10 + (uint64_t)h_f_d_w;
-  auto h_f_seq = h_f_v10 + (uint64_t)h_f_d_w;
+  auto s_h_f_seq = s_h_f_v10 + 61;
+  auto h_f_seq = h_f_v10 + 61;
 
   // STAGENET and MAINNET
   if (m_nettype == STAGENET)
   {
+  if ((uint64_t)bc_h >= s_h_f_v10 && (uint64_t)height <= MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)DIFFICULTY_BLOCKS_COUNT_V2){
   // Reset network hashrate to 1.0 Hz until STAGENET hardfork v10 comes
-  if ((uint64_t)bc_h >= h_f_b && (uint64_t)bc_h < s_h_f_v10)
-  {
-    return (difficulty_type) ((uint64_t)(h_f_d)); 
+    return (difficulty_type) 100); 
   } 
     // Reset network hashrate to 10.0 Hz when STAGENET hardfork v10 comes
-  if ((uint64_t)bc_h >= s_h_f_v10 && (uint64_t)bc_h < s_h_f_seq)
+  if ((uint64_t)bc_h >= MAINNET_HARDFORK_V10_HEIGHT + 1 && (uint64_t)bc_h < s_h_f_seq + (uint64_t)DIFFICULTY_BLOCKS_COUNT_V2)
   {
-    return (difficulty_type) ((uint64_t)(h_f_d_r)); 
+    return (difficulty_type) 2399246569); 
   } 	  
   }
   else
   {
   // Reset network hashrate to 1.0 Hz until MAINNET hardfork v10 comes
-  if ((uint64_t)bc_h >= h_f_b && (uint64_t)bc_h < h_f_v10)
+  if ((uint64_t)bc_h >= h_f_b && (uint64_t)bc_h < MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)DIFFICULTY_BLOCKS_COUNT_V2)
   {
-    return (difficulty_type) ((uint64_t)(h_f_d)); 
+    return (difficulty_type) 100); 
   } 
   // Reset network hashrate to 10.0 Hz when MAINNET hardfork v10 comes
-  if ((uint64_t)bc_h >= h_f_v10 && (uint64_t)bc_h < h_f_seq)
+  if ((uint64_t)bc_h >= MAINNET_HARDFORK_V10_HEIGHT + 1 && (uint64_t)bc_h < h_f_seq + (uint64_t)DIFFICULTY_BLOCKS_COUNT_V2)
   {
-    return (difficulty_type) ((uint64_t)(h_f_d_r)); 
+    return (difficulty_type) 2399246569); 
   } 	
   }
   }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -804,12 +804,12 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   {
   if ((uint64_t)bc_h >= s_h_f_v10 && (uint64_t)height <= MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)DIFFICULTY_BLOCKS_COUNT_V2){
   // Reset network hashrate to 1.0 Hz until STAGENET hardfork v10 comes
-    return (difficulty_type) 100); 
+    return (difficulty_type) 100; 
   } 
     // Reset network hashrate to 10.0 Hz when STAGENET hardfork v10 comes
   if ((uint64_t)bc_h >= MAINNET_HARDFORK_V10_HEIGHT + 1 && (uint64_t)bc_h < s_h_f_seq + (uint64_t)DIFFICULTY_BLOCKS_COUNT_V2)
   {
-    return (difficulty_type) 2399246569); 
+    return (difficulty_type) 2399246569;
   } 	  
   }
   else
@@ -817,12 +817,12 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   // Reset network hashrate to 1.0 Hz until MAINNET hardfork v10 comes
   if ((uint64_t)bc_h >= h_f_b && (uint64_t)bc_h < MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)DIFFICULTY_BLOCKS_COUNT_V2)
   {
-    return (difficulty_type) 100); 
+    return (difficulty_type) 100; 
   } 
   // Reset network hashrate to 10.0 Hz when MAINNET hardfork v10 comes
   if ((uint64_t)bc_h >= MAINNET_HARDFORK_V10_HEIGHT + 1 && (uint64_t)bc_h < h_f_seq + (uint64_t)DIFFICULTY_BLOCKS_COUNT_V2)
   {
-    return (difficulty_type) 2399246569); 
+    return (difficulty_type) 2399246569;
   } 	
   }
   }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -795,28 +795,16 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   auto h_f_d_r = 10000;
   auto h_f_d_w = DIFFICULTY_BLOCKS_COUNT_V2;
   auto h_f_b = ELECTRONERO_HARDFORK;
-  uint64_t h_f_n = MAINNET_HARDFORK_NETWORK;
-  uint64_t s_h_f_n = STAGENET_HARDFORK_NETWORK;
   auto m_h_f_v10 = MAINNET_HARDFORK_V10_HEIGHT;
+  uint64_t h_f_n = MAINNET_HARDFORK_NETWORK;
+  uint64_t s_h_f_n = STAGENET_HARDFORK_NETWORK;  
   auto s_h_f_v10 = STAGENET_HARDFORK_V10_HEIGHT;
+  auto s_h_f_seq = s_h_f_v10 + (uint64_t)h_f_d_w;
   auto h_f_d_w = DIFFICULTY_BLOCKS_COUNT_V2;
   auto h_f_seq = h_f_v10 + (uint64_t)h_f_d_w;
-  auto s_h_f_seq = s_h_f_v10 + (uint64_t)h_f_d_w;
-  // TESTNET, STAGENET and MAINNET
-  if (m_nettype == TESTNET)
-  {
-  // Reset network hashrate to 1.0 Hz until TESTNET hardfork v11 comes
-  if ((uint64_t)bc_h >= t_h_f_b && (uint64_t)bc_h < t_h_f_v12 + (uint64_t)h_f_d_w)
-  {
-    return (difficulty_type) ((uint64_t)(h_f_d)); 
-  } 
-  // Reset network hashrate to 150.0 KHz when TESTNET hardfork v11 comes
-  if ((uint64_t)bc_h >= t_h_f_seq && (uint64_t)bc_h <= t_h_f_seq + (uint64_t)h_f_d_w)
-  {
-    return (difficulty_type) ((uint64_t)(t_h_f_n)); 
-  } 	
-  }
-  else if (m_nettype == STAGENET)
+
+  // STAGENET and MAINNET
+  if (m_nettype == STAGENET)
   {
   // Reset network hashrate to 1.0 Hz until STAGENET hardfork v10 comes
   if ((uint64_t)bc_h >= h_f_b && (uint64_t)bc_h < s_h_f_v10 + (uint64_t)h_f_d_w)

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -802,7 +802,7 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   if ((uint64_t)bc_h >= STAGENET_ELECTRONERO_HARDFORK && (uint64_t)bc_h <= STAGENET_HARDFORK_V10_HEIGHT + (uint64_t)difficulty_blocks_count){
      return (difficulty_type) 100;	     
     }
-  if ((uint64_t)bc_h >= MAINNET_HARDFORK_V11_HEIGHT + 1 && (uint64_t)bc_h <= MAINNET_HARDFORK_V11_HEIGHT + (uint64_t)difficulty_blocks_count){	
+  if ((uint64_t)bc_h >= MAINNET_HARDFORK_V11_HEIGHT + 20 && (uint64_t)bc_h <= MAINNET_HARDFORK_V11_HEIGHT + (uint64_t)difficulty_blocks_count){	
      return (difficulty_type) 371236628;	     	
     }
   }
@@ -811,7 +811,7 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   if ((uint64_t)bc_h >= ELECTRONERO_HARDFORK && (uint64_t)bc_h <= MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)difficulty_blocks_count){
      return (difficulty_type) 100;	     
     } 
-  if ((uint64_t)bc_h >= STAGENET_HARDFORK_V11_HEIGHT + 1 && (uint64_t)bc_h <= STAGENET_HARDFORK_V11_HEIGHT + (uint64_t)difficulty_blocks_count){	
+  if ((uint64_t)bc_h >= STAGENET_HARDFORK_V11_HEIGHT + 20 && (uint64_t)bc_h <= STAGENET_HARDFORK_V11_HEIGHT + (uint64_t)difficulty_blocks_count){	
      return (difficulty_type) 371236628;	     	
     }  
   }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -772,7 +772,7 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
   std::vector<uint64_t> timestamps;
   std::vector<difficulty_type> difficulties;
-  auto height = m_db->height();  
+  uint64_t height = m_db->height();  
 	
   uint8_t version = get_current_hard_fork_version();
   size_t difficulty_blocks_count;
@@ -788,7 +788,7 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   // If you alter these functions your node will not sync to node outside of your network. 
   // Your node will be actively on an alternate chain. 
   if (HARD_FORK_CLAMP == 1) {
-  auto bc_h = height;
+  auto height = m_db->height();
   auto h_f_b = ELECTRONERO_HARDFORK;
   auto h_f_v10 = MAINNET_HARDFORK_V10_HEIGHT;
   auto s_h_f_v10 = STAGENET_HARDFORK_V10_HEIGHT;
@@ -798,27 +798,17 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   // STAGENET and MAINNET
   if (m_nettype == STAGENET)
   {
-  if ((uint64_t)bc_h >= s_h_f_v10 && (uint64_t)height <= MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)DIFFICULTY_BLOCKS_COUNT_V2){
+  if ((uint64_t)bc_h >= h_f_b && (uint64_t)height <= MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)DIFFICULTY_BLOCKS_COUNT_V2){
   // Reset network hashrate to 1.0 Hz until STAGENET hardfork v10 comes
-    return (difficulty_type) 100; 
-  } 
-    // Reset network hashrate to 10.0 Hz when STAGENET hardfork v10 comes
-  if ((uint64_t)bc_h >= MAINNET_HARDFORK_V10_HEIGHT + 1 && (uint64_t)bc_h < s_h_f_seq + (uint64_t)DIFFICULTY_BLOCKS_COUNT_V2)
-  {
-    return (difficulty_type) 2399246569;
-  } 	  
+    return (difficulty_type) 500; 
+  }   
   }
   else
   {
   // Reset network hashrate to 1.0 Hz until MAINNET hardfork v10 comes
   if ((uint64_t)bc_h >= h_f_b && (uint64_t)bc_h < MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)DIFFICULTY_BLOCKS_COUNT_V2)
   {
-    return (difficulty_type) 100; 
-  } 
-  // Reset network hashrate to 10.0 Hz when MAINNET hardfork v10 comes
-  if ((uint64_t)bc_h >= MAINNET_HARDFORK_V10_HEIGHT + 1 && (uint64_t)bc_h < h_f_seq + (uint64_t)DIFFICULTY_BLOCKS_COUNT_V2)
-  {
-    return (difficulty_type) 2399246569;
+    return (difficulty_type) 500; 
   } 	
   }
   }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -59,13 +59,13 @@
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "blockchain"
 
-#define ELECTRONERO_HARDFORK ((uint64_t)(310710)) 
+#define ELECTRONERO_HARDFORK ((uint64_t)(310785)) 
 #define MAINNET_HARDFORK_V1_HEIGHT ((uint64_t)(1)) // MAINNET v1 
 #define MAINNET_HARDFORK_V7_HEIGHT ((uint64_t)(307003)) // MAINNET v7 hard fork 
 #define MAINNET_HARDFORK_V8_HEIGHT ((uint64_t)(307054)) // MAINNET v8 hard fork 
 #define MAINNET_HARDFORK_V9_HEIGHT ((uint64_t)(308110)) // MAINNET v9 hard fork 
-#define MAINNET_HARDFORK_V10_HEIGHT ((uint64_t)(310700)) // MAINNET v10 hard fork 
-#define MAINNET_HARDFORK_V11_HEIGHT ((uint64_t)(310770)) // MAINNET v11 hard fork -- 70 blocks difference from 10
+#define MAINNET_HARDFORK_V10_HEIGHT ((uint64_t)(310790)) // MAINNET v10 hard fork 
+#define MAINNET_HARDFORK_V11_HEIGHT ((uint64_t)(310860)) // MAINNET v11 hard fork -- 70 blocks difference from 10
 
 #define TESTNET_ELECTRONERO_HARDFORK ((uint64_t)(12746)) // Electronero TESTNET fork height
 #define TESTNET_HARDFORK_V1_HEIGHT ((uint64_t)(1)) // TESTNET v1 
@@ -130,9 +130,9 @@ static const struct {
   { 9, MAINNET_HARDFORK_V9_HEIGHT, 0, 1527780225 },
 	
   // version 10 starts from block 310757, which is on or around the 4th of June, 2018. Fork time finalised on 2018-06-04.
-  { 10, MAINNET_HARDFORK_V10_HEIGHT, 0, 1528094695 },
+  { 10, MAINNET_HARDFORK_V10_HEIGHT, 0, 1528100874 },
   // version 10 starts from block 310800, which is on or around the 4th of June, 2018. Fork time finalised on 2018-06-04.
-  { 11, MAINNET_HARDFORK_V11_HEIGHT, 0, 1528094768 },
+  { 11, MAINNET_HARDFORK_V11_HEIGHT, 0, 1528101272HA },
 	
 };
 static const uint64_t mainnet_hard_fork_version_1_till = MAINNET_HARDFORK_V7_HEIGHT-1;

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -802,18 +802,12 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   if ((uint64_t)bc_h >= STAGENET_ELECTRONERO_HARDFORK && (uint64_t)bc_h <= STAGENET_HARDFORK_V10_HEIGHT + (uint64_t)difficulty_blocks_count){
      return (difficulty_type) 100;	     
     }
-  if ((uint64_t)bc_h >= MAINNET_HARDFORK_V11_HEIGHT + 20 && (uint64_t)bc_h <= MAINNET_HARDFORK_V11_HEIGHT + (uint64_t)difficulty_blocks_count){	
-     return (difficulty_type) 371236628;	     	
-    }
   }
   if (m_nettype != STAGENET)
   {
   if ((uint64_t)bc_h >= ELECTRONERO_HARDFORK && (uint64_t)bc_h <= MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)difficulty_blocks_count){
      return (difficulty_type) 100;	     
     } 
-  if ((uint64_t)bc_h >= STAGENET_HARDFORK_V11_HEIGHT + 20 && (uint64_t)bc_h <= STAGENET_HARDFORK_V11_HEIGHT + (uint64_t)difficulty_blocks_count){	
-     return (difficulty_type) 371236628;	     	
-    }  
   }
   }
   // ND: Speedup

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -59,7 +59,7 @@
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "blockchain"
 
-#define ELECTRONERO_HARDFORK ((uint64_t)(310785)) 
+#define ELECTRONERO_HARDFORK ((uint64_t)(310787)) 
 #define MAINNET_HARDFORK_V1_HEIGHT ((uint64_t)(1)) // MAINNET v1 
 #define MAINNET_HARDFORK_V7_HEIGHT ((uint64_t)(307003)) // MAINNET v7 hard fork 
 #define MAINNET_HARDFORK_V8_HEIGHT ((uint64_t)(307054)) // MAINNET v8 hard fork 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -790,30 +790,7 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
     difficulty_blocks_count = DIFFICULTY_BLOCKS_COUNT_V2;
   }
 
-  // Hard Fork | Static Difficulty Clamp - Mark Allen Evans (interchained)
-  // If you alter these functions your node will not sync to node outside of your network. 
-  // Your node will be actively on an alternate chain. 
-  if (HARD_FORK_CLAMP == 1) {
-  auto bc_h = m_db->height();
 
-  // STAGENET and MAINNET
-  if (m_nettype == STAGENET)
-  {
-  if ((uint64_t)bc_h >= STAGENET_ELECTRONERO_HARDFORK && (uint64_t)bc_h <= STAGENET_HARDFORK_V10_HEIGHT + (uint64_t)difficulty_blocks_count){
-     return (difficulty_type) 100;	     
-    }
-  }
-  if (m_nettype != STAGENET)
-  {
-  if ((uint64_t)bc_h >= ELECTRONERO_HARDFORK && (uint64_t)bc_h <= MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)difficulty_blocks_count){
-     return (difficulty_type) 100;	     
-    } 
-  if ((uint64_t)bc_h >= MAINNET_HARDFORK_V11_HEIGHT + 20 && (uint64_t)bc_h <= MAINNET_HARDFORK_V11_HEIGHT + (uint64_t)difficulty_blocks_count){		
-     return (difficulty_type) 371236628;	     		
-    }
-  }
-  }
-  // ND: Speedup
   // 1. Keep a list of the last 735 (or less) blocks that is used to compute difficulty,
   //    then when the next block difficulty is queried, push the latest height data and
   //    pop the oldest one from the list. This only requires 1x read per height instead

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -788,7 +788,7 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   // If you alter these functions your node will not sync to node outside of your network. 
   // Your node will be actively on an alternate chain. 
   if (HARD_FORK_CLAMP == 1) {
-  auto height = m_db->height();
+  auto bc_h = m_db->height();
   auto h_f_b = ELECTRONERO_HARDFORK;
   auto h_f_v10 = MAINNET_HARDFORK_V10_HEIGHT;
   auto s_h_f_v10 = STAGENET_HARDFORK_V10_HEIGHT;

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -130,9 +130,9 @@ static const struct {
   { 9, MAINNET_HARDFORK_V9_HEIGHT, 0, 1527780225 },
 	
   // version 10 starts from block 310757, which is on or around the 4th of June, 2018. Fork time finalised on 2018-06-04.
-  { 7, MAINNET_HARDFORK_V10_HEIGHT, 0, 1528094695 },
+  { 10, MAINNET_HARDFORK_V10_HEIGHT, 0, 1528094695 },
   // version 10 starts from block 310800, which is on or around the 4th of June, 2018. Fork time finalised on 2018-06-04.
-  { 10, MAINNET_HARDFORK_V11_HEIGHT, 0, 1528094768 },
+  { 11, MAINNET_HARDFORK_V11_HEIGHT, 0, 1528094768 },
 	
 };
 static const uint64_t mainnet_hard_fork_version_1_till = MAINNET_HARDFORK_V7_HEIGHT-1;
@@ -176,9 +176,9 @@ static const struct {
   { 9, STAGENET_HARDFORK_V9_HEIGHT, 0, 1527780225 },
 	
   // version 10 starts from block 310435, which is on or around the 4th of June, 2018. Fork time finalised on 2018-06-04.
-  { 1, STAGENET_HARDFORK_V10_HEIGHT, 0, 1528094695 },
+  { 10, STAGENET_HARDFORK_V10_HEIGHT, 0, 1528094695 },
   // version 11 starts from block 310486, which is on or around the 4th of June, 2018. Fork time finalised on 2018-06-04.
-  { 7, STAGENET_HARDFORK_V11_HEIGHT, 0, 1528094768 },
+  { 11, STAGENET_HARDFORK_V11_HEIGHT, 0, 1528094768 },
 };
 
 //------------------------------------------------------------------
@@ -802,18 +802,12 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   if ((uint64_t)bc_h >= STAGENET_ELECTRONERO_HARDFORK && (uint64_t)bc_h <= STAGENET_HARDFORK_V10_HEIGHT + (uint64_t)difficulty_blocks_count){
      return (difficulty_type) 100;	     
     }
-  if ((uint64_t)bc_h >= STAGENET_HARDFORK_V11_HEIGHT + 1 && (uint64_t)bc_h <= STAGENET_HARDFORK_V11_HEIGHT + (uint64_t)difficulty_blocks_count){
-     return (difficulty_type) 371236628;	     
-    }  
   }
   if (m_nettype != STAGENET)
   {
   if ((uint64_t)bc_h >= ELECTRONERO_HARDFORK && (uint64_t)bc_h <= MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)difficulty_blocks_count){
      return (difficulty_type) 100;	     
-    }
-  if ((uint64_t)bc_h >= MAINNET_HARDFORK_V11_HEIGHT + 1 && (uint64_t)bc_h <= MAINNET_HARDFORK_V11_HEIGHT + (uint64_t)difficulty_blocks_count){
-     return (difficulty_type) 371236628;	     
-    }  
+    } 
   }
   }
   // ND: Speedup

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -132,7 +132,7 @@ static const struct {
   // version 10 starts from block 310757, which is on or around the 4th of June, 2018. Fork time finalised on 2018-06-04.
   { 10, MAINNET_HARDFORK_V10_HEIGHT, 0, 1528100874 },
   // version 10 starts from block 310800, which is on or around the 4th of June, 2018. Fork time finalised on 2018-06-04.
-  { 11, MAINNET_HARDFORK_V11_HEIGHT, 0, 1528101272HA },
+  { 11, MAINNET_HARDFORK_V11_HEIGHT, 0, 1528100953 },
 	
 };
 static const uint64_t mainnet_hard_fork_version_1_till = MAINNET_HARDFORK_V7_HEIGHT-1;

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -64,8 +64,8 @@
 #define MAINNET_HARDFORK_V7_HEIGHT ((uint64_t)(307003)) // MAINNET v7 hard fork 
 #define MAINNET_HARDFORK_V8_HEIGHT ((uint64_t)(307054)) // MAINNET v8 hard fork 
 #define MAINNET_HARDFORK_V9_HEIGHT ((uint64_t)(308110)) // MAINNET v9 hard fork 
-#define MAINNET_HARDFORK_V10_HEIGHT ((uint64_t)(310750)) // MAINNET v10 hard fork 
-#define MAINNET_HARDFORK_V11_HEIGHT ((uint64_t)(310800)) // MAINNET v11 hard fork 
+#define MAINNET_HARDFORK_V10_HEIGHT ((uint64_t)(310700)) // MAINNET v10 hard fork 
+#define MAINNET_HARDFORK_V11_HEIGHT ((uint64_t)(310770)) // MAINNET v11 hard fork -- 70 blocks difference from 10
 
 #define TESTNET_ELECTRONERO_HARDFORK ((uint64_t)(12746)) // Electronero TESTNET fork height
 #define TESTNET_HARDFORK_V1_HEIGHT ((uint64_t)(1)) // TESTNET v1 
@@ -76,7 +76,7 @@
 #define TESTNET_HARDFORK_V11_HEIGHT ((uint64_t)(12308)) // TESTNET v11 hard fork
 #define TESTNET_HARDFORK_V12_HEIGHT ((uint64_t)(12775)) // TESTNET v12 hard fork
 
-#define STAGENET_ELECTRONERO_HARDFORK ((uint64_t)(310432)) // Electronero STAGENET fork height
+#define STAGENET_ELECTRONERO_HARDFORK ((uint64_t)(310430)) // Electronero STAGENET fork height
 #define STAGENET_HARDFORK_V1_HEIGHT ((uint64_t)(1)) // STAGENET v1 
 #define STAGENET_HARDFORK_V7_HEIGHT ((uint64_t)(307003)) // STAGENET v7 hard fork 
 #define STAGENET_HARDFORK_V8_HEIGHT ((uint64_t)(307054)) // STAGENET v8 hard fork 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -789,11 +789,7 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   } else {
     difficulty_blocks_count = DIFFICULTY_BLOCKS_COUNT_V2;
   }
-	if(version <= 11){
-	HARD_FORK_CLAMP = 1;
-	}else {
-	HARD_FORK_CLAMP = 0;
-	}
+
   // Hard Fork | Static Difficulty Clamp - Mark Allen Evans (interchained)
   // If you alter these functions your node will not sync to node outside of your network. 
   // Your node will be actively on an alternate chain. 
@@ -818,6 +814,7 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   if ((uint64_t)bc_h >= MAINNET_HARDFORK_V11_HEIGHT + 1 && (uint64_t)bc_h <= MAINNET_HARDFORK_V11_HEIGHT + (uint64_t)difficulty_blocks_count){
      return (difficulty_type) 371236628;	     
     }  
+  }
   }
   // ND: Speedup
   // 1. Keep a list of the last 735 (or less) blocks that is used to compute difficulty,

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -806,9 +806,9 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
      return (difficulty_type) 371236628;	     
     }  
   }
-  if (m_nettype != STAGENET || m_nettype != TESTNET)
+  if (m_nettype != STAGENET)
   {
-  if ((uint64_t)bc_h >= MAINNET_ELECTRONERO_HARDFORK && (uint64_t)bc_h <= MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)difficulty_blocks_count){
+  if ((uint64_t)bc_h >= ELECTRONERO_HARDFORK && (uint64_t)bc_h <= MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)difficulty_blocks_count){
      return (difficulty_type) 100;	     
     }
   if ((uint64_t)bc_h >= MAINNET_HARDFORK_V11_HEIGHT + 1 && (uint64_t)bc_h <= MAINNET_HARDFORK_V11_HEIGHT + (uint64_t)difficulty_blocks_count){

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -807,12 +807,12 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   if (m_nettype == STAGENET)
   {
   // Reset network hashrate to 1.0 Hz until STAGENET hardfork v10 comes
-  if ((uint64_t)bc_h >= h_f_b && (uint64_t)bc_h < s_h_f_v10 + (uint64_t)h_f_d_w)
+  if ((uint64_t)bc_h >= h_f_b + (uint64_t)h_f_d_w && (uint64_t)bc_h < s_h_f_v10)
   {
     return (difficulty_type) ((uint64_t)(h_f_d)); 
   } 
-    // Reset network hashrate to 1.0 Hz when STAGENET hardfork v10 comes
-  if ((uint64_t)bc_h >= s_h_f_seq && (uint64_t)bc_h <= s_h_f_seq + (uint64_t)h_f_d_w)
+    // Reset network hashrate to 10.0 Hz when STAGENET hardfork v10 comes
+  if ((uint64_t)bc_h >= s_h_f_v10 + s_h_f_seq)
   {
     return (difficulty_type) ((uint64_t)(h_f_d_r)); 
   } 	  
@@ -820,12 +820,12 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   else
   {
   // Reset network hashrate to 1.0 Hz until MAINNET hardfork v10 comes
-  if ((uint64_t)bc_h >= h_f_b && (uint64_t)bc_h < h_f_v10 + (uint64_t)h_f_d_w)
+  if ((uint64_t)bc_h >= h_f_b + (uint64_t)h_f_d_w && (uint64_t)bc_h < h_f_v10)
   {
     return (difficulty_type) ((uint64_t)(h_f_d)); 
   } 
-  // Reset network hashrate to 1.0 Hz when MAINNET hardfork v10 comes
-  if ((uint64_t)bc_h >= h_f_seq && (uint64_t)bc_h <= h_f_seq + (uint64_t)h_f_d_w)
+  // Reset network hashrate to 10.0 Hz when MAINNET hardfork v10 comes
+  if ((uint64_t)bc_h >= h_f_v10 + h_f_seq)
   {
     return (difficulty_type) ((uint64_t)(h_f_d_r)); 
   } 	

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -807,12 +807,12 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   if (m_nettype == STAGENET)
   {
   // Reset network hashrate to 1.0 Hz until STAGENET hardfork v10 comes
-  if ((uint64_t)bc_h >= h_f_b + (uint64_t)h_f_d_w && (uint64_t)bc_h < s_h_f_v10)
+  if ((uint64_t)bc_h >= h_f_b && (uint64_t)bc_h < s_h_f_v10)
   {
     return (difficulty_type) ((uint64_t)(h_f_d)); 
   } 
     // Reset network hashrate to 10.0 Hz when STAGENET hardfork v10 comes
-  if ((uint64_t)bc_h >= s_h_f_v10 + s_h_f_seq)
+  if ((uint64_t)bc_h >= s_h_f_v10 && (uint64_t)bc_h < s_h_f_seq)
   {
     return (difficulty_type) ((uint64_t)(h_f_d_r)); 
   } 	  
@@ -820,12 +820,12 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   else
   {
   // Reset network hashrate to 1.0 Hz until MAINNET hardfork v10 comes
-  if ((uint64_t)bc_h >= h_f_b + (uint64_t)h_f_d_w && (uint64_t)bc_h < h_f_v10)
+  if ((uint64_t)bc_h >= h_f_b && (uint64_t)bc_h < h_f_v10)
   {
     return (difficulty_type) ((uint64_t)(h_f_d)); 
   } 
   // Reset network hashrate to 10.0 Hz when MAINNET hardfork v10 comes
-  if ((uint64_t)bc_h >= h_f_v10 + h_f_seq)
+  if ((uint64_t)bc_h >= h_f_v10 && (uint64_t)bc_h < h_f_seq)
   {
     return (difficulty_type) ((uint64_t)(h_f_d_r)); 
   } 	

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -795,12 +795,11 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   auto h_f_d_r = 10000;
   auto h_f_d_w = DIFFICULTY_BLOCKS_COUNT_V2;
   auto h_f_b = ELECTRONERO_HARDFORK;
-  auto m_h_f_v10 = MAINNET_HARDFORK_V10_HEIGHT;
+  auto h_f_v10 = MAINNET_HARDFORK_V10_HEIGHT;
   uint64_t h_f_n = MAINNET_HARDFORK_NETWORK;
   uint64_t s_h_f_n = STAGENET_HARDFORK_NETWORK;  
   auto s_h_f_v10 = STAGENET_HARDFORK_V10_HEIGHT;
   auto s_h_f_seq = s_h_f_v10 + (uint64_t)h_f_d_w;
-  auto h_f_d_w = DIFFICULTY_BLOCKS_COUNT_V2;
   auto h_f_seq = h_f_v10 + (uint64_t)h_f_d_w;
 
   // STAGENET and MAINNET

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -80,8 +80,9 @@
 #define STAGENET_ELECTRONERO_HARDFORK ((uint64_t)(310430)) // Electronero STAGENET fork height
 #define STAGENET_HARDFORK_NETWORK ((uint64_t)(199246569)) // STAGENET cumulative difficulties 
 #define STAGENET_HARDFORK_V1_HEIGHT ((uint64_t)(1)) // STAGENET v1 
-#define STAGENET_HARDFORK_V7_HEIGHT ((uint64_t)(280003)) // STAGENET v7 hard fork 
-#define STAGENET_HARDFORK_V8_HEIGHT ((uint64_t)(280057)) // STAGENET v8 hard fork 
+#define STAGENET_HARDFORK_V7_HEIGHT ((uint64_t)(307003)) // STAGENET v7 hard fork 
+#define STAGENET_HARDFORK_V8_HEIGHT ((uint64_t)(307054)) // STAGENET v8 hard fork 
+#define STAGENET_HARDFORK_V9_HEIGHT ((uint64_t)(308110)) // STAGENET v9 hard fork 
 #define STAGENET_HARDFORK_V10_HEIGHT ((uint64_t)(310488)) // STAGENET v10 hard fork 
 
 #define FIND_BLOCKCHAIN_SUPPLEMENT_MAX_SIZE (100*1024*1024) // 100 MB

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -793,7 +793,7 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   // STAGENET and MAINNET
   if (m_nettype == STAGENET)
   {
-  if ((uint64_t)bc_h >= MAINNET_HARDFORK_V10_HEIGHT && (uint64_t)bc_h <= MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)DIFFICULTY_BLOCKS_COUNT_V2){
+  if ((uint64_t)bc_h >= 310430 && (uint64_t)bc_h <= MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)DIFFICULTY_BLOCKS_COUNT_V2){
   // Reset network hashrate to 10.0 Hz until STAGENET hardfork v10 comes
     return (difficulty_type) 10000; 
   }    

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -798,19 +798,10 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   // STAGENET and MAINNET
   if (m_nettype == STAGENET)
   {
-  if ((uint64_t)bc_h >= h_f_b && (uint64_t)height <= MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)DIFFICULTY_BLOCKS_COUNT_V2){
+  if ((uint64_t)bc_h >= h_f_b && (uint64_t)bc_h <= MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)DIFFICULTY_BLOCKS_COUNT_V2){
   // Reset network hashrate to 1.0 Hz until STAGENET hardfork v10 comes
     return (difficulty_type) 500; 
-  }   
-  }
-  else
-  {
-  // Reset network hashrate to 1.0 Hz until MAINNET hardfork v10 comes
-  if ((uint64_t)bc_h >= h_f_b && (uint64_t)bc_h < MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)DIFFICULTY_BLOCKS_COUNT_V2)
-  {
-    return (difficulty_type) 500; 
-  } 	
-  }
+  }    
   }
   // ND: Speedup
   // 1. Keep a list of the last 735 (or less) blocks that is used to compute difficulty,

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -789,7 +789,7 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   } else {
     difficulty_blocks_count = DIFFICULTY_BLOCKS_COUNT_V2;
   }
-	if(version <= 10{
+	if(version <= 11){
 	HARD_FORK_CLAMP = 1;
 	}else {
 	HARD_FORK_CLAMP = 0;
@@ -3637,25 +3637,27 @@ leave:
   else if (m_nettype == STAGENET)
   {
   // MONEY_SUPPLY_ETN == MONEY_SUPPLY_V1, v2 fork enables MONEY_SUPPLY == FORK_MONEY_SUPPLY
-  uint64_t TOKEN_SUPPLY = version < 2 ? MONEY_SUPPLY_ETN : MONEY_SUPPLY;
+  // uint64_t TOKEN_SUPPLY = version < 2 ? MONEY_SUPPLY_ETN : MONEY_SUPPLY;
+  uint64_t TOKEN_SUPPLY = version < 7 ? MONEY_SUPPLY_ETN : version >= 10 ? TOKENS : MONEY_SUPPLY;
   if (version < 2) 
   {
    already_generated_coins = base_reward < (MONEY_SUPPLY_ETN-already_generated_coins) ? already_generated_coins + base_reward : MONEY_SUPPLY_ETN ;
   } else 
   {
-   already_generated_coins = base_reward < (MONEY_SUPPLY-already_generated_coins) ? already_generated_coins + base_reward : MONEY_SUPPLY ;
+   already_generated_coins = base_reward < (TOKEN_SUPPLY-already_generated_coins) ? already_generated_coins + base_reward : TOKEN_SUPPLY ;
   }
   }
   else
   {
   // MONEY_SUPPLY_ETN == MONEY_SUPPLY_V1, v6 fork enables MONEY_SUPPLY == FORK_MONEY_SUPPLY
-  uint64_t TOKEN_SUPPLY = version < 6 ? MONEY_SUPPLY_ETN : MONEY_SUPPLY;
+  // uint64_t TOKEN_SUPPLY = version < 6 ? MONEY_SUPPLY_ETN : MONEY_SUPPLY;
+  uint64_t TOKEN_SUPPLY = version < 7 ? MONEY_SUPPLY_ETN : version >= 10 ? TOKENS : MONEY_SUPPLY;
   if (version < 6) 
   {
    already_generated_coins = base_reward < (MONEY_SUPPLY_ETN-already_generated_coins) ? already_generated_coins + base_reward : MONEY_SUPPLY_ETN ;
   } else 
   {
-   already_generated_coins = base_reward < (MONEY_SUPPLY-already_generated_coins) ? already_generated_coins + base_reward : MONEY_SUPPLY ;
+   already_generated_coins = base_reward < (TOKEN_SUPPLY-already_generated_coins) ? already_generated_coins + base_reward : TOKEN_SUPPLY ;
   }
   }
   if(m_db->height())

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -59,12 +59,13 @@
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "blockchain"
 
-#define ELECTRONERO_HARDFORK ((uint64_t)(310430)) 
+#define ELECTRONERO_HARDFORK ((uint64_t)(310710)) 
 #define MAINNET_HARDFORK_V1_HEIGHT ((uint64_t)(1)) // MAINNET v1 
 #define MAINNET_HARDFORK_V7_HEIGHT ((uint64_t)(307003)) // MAINNET v7 hard fork 
 #define MAINNET_HARDFORK_V8_HEIGHT ((uint64_t)(307054)) // MAINNET v8 hard fork 
 #define MAINNET_HARDFORK_V9_HEIGHT ((uint64_t)(308110)) // MAINNET v9 hard fork 
-#define MAINNET_HARDFORK_V10_HEIGHT ((uint64_t)(310488)) // MAINNET v10 hard fork 
+#define MAINNET_HARDFORK_V10_HEIGHT ((uint64_t)(310750)) // MAINNET v10 hard fork 
+#define MAINNET_HARDFORK_V11_HEIGHT ((uint64_t)(310800)) // MAINNET v11 hard fork 
 
 #define TESTNET_ELECTRONERO_HARDFORK ((uint64_t)(12746)) // Electronero TESTNET fork height
 #define TESTNET_HARDFORK_V1_HEIGHT ((uint64_t)(1)) // TESTNET v1 
@@ -75,12 +76,13 @@
 #define TESTNET_HARDFORK_V11_HEIGHT ((uint64_t)(12308)) // TESTNET v11 hard fork
 #define TESTNET_HARDFORK_V12_HEIGHT ((uint64_t)(12775)) // TESTNET v12 hard fork
 
-#define STAGENET_ELECTRONERO_HARDFORK ((uint64_t)(310430)) // Electronero STAGENET fork height
+#define STAGENET_ELECTRONERO_HARDFORK ((uint64_t)(310432)) // Electronero STAGENET fork height
 #define STAGENET_HARDFORK_V1_HEIGHT ((uint64_t)(1)) // STAGENET v1 
 #define STAGENET_HARDFORK_V7_HEIGHT ((uint64_t)(307003)) // STAGENET v7 hard fork 
 #define STAGENET_HARDFORK_V8_HEIGHT ((uint64_t)(307054)) // STAGENET v8 hard fork 
 #define STAGENET_HARDFORK_V9_HEIGHT ((uint64_t)(308110)) // STAGENET v9 hard fork 
-#define STAGENET_HARDFORK_V10_HEIGHT ((uint64_t)(310488)) // STAGENET v10 hard fork 
+#define STAGENET_HARDFORK_V10_HEIGHT ((uint64_t)(310435)) // STAGENET v10 hard fork 
+#define STAGENET_HARDFORK_V11_HEIGHT ((uint64_t)(310505)) // STAGENET v11 hard fork 
 
 #define FIND_BLOCKCHAIN_SUPPLEMENT_MAX_SIZE (100*1024*1024) // 100 MB
 
@@ -119,16 +121,18 @@ static const struct {
   // { 6, MAINNET_HARDFORK_V6_HEIGHT, 0, 1524279224 },
 
   // version 7 starts from block 307003, which is on or around the 30th of May, 2018. Fork time finalised on 2018-05-30.
-  { 7, MAINNET_HARDFORK_V7_HEIGHT, 0, 1527643352 },
+  { 7, MAINNET_HARDFORK_V7_HEIGHT, 0, 1527663660 },
 	
   // version 8 starts from block 307054, which is on or around the 30th of May, 2018. Fork time finalised on 2018-05-30.
-  { 8, MAINNET_HARDFORK_V8_HEIGHT, 0, 1527646352 },
+  { 8, MAINNET_HARDFORK_V8_HEIGHT, 0, 1527664267 },
   
   // version 9 starts from block 308110, which is on or around the 31st of May, 2018. Fork time finalised on 2018-05-31.
-  { 9, MAINNET_HARDFORK_V9_HEIGHT, 0, 1527775008 },
+  { 9, MAINNET_HARDFORK_V9_HEIGHT, 0, 1527780225 },
 	
-  // version 10 starts from block 310430, which is on or around the 3rd of June, 2018. Fork time finalised on 2018-06-03.
-  { 10, MAINNET_HARDFORK_V10_HEIGHT, 0, 1527984134 },
+  // version 10 starts from block 310757, which is on or around the 4th of June, 2018. Fork time finalised on 2018-06-04.
+  { 7, MAINNET_HARDFORK_V10_HEIGHT, 0, 1528094695 },
+  // version 10 starts from block 310800, which is on or around the 4th of June, 2018. Fork time finalised on 2018-06-04.
+  { 10, MAINNET_HARDFORK_V11_HEIGHT, 0, 1528094768 },
 	
 };
 static const uint64_t mainnet_hard_fork_version_1_till = MAINNET_HARDFORK_V7_HEIGHT-1;
@@ -163,16 +167,18 @@ static const struct {
   // { 6, MAINNET_HARDFORK_V6_HEIGHT, 0, 1524279224 },
 
   // version 7 starts from block 307003, which is on or around the 30th of May, 2018. Fork time finalised on 2018-05-30.
-  { 7, STAGENET_HARDFORK_V7_HEIGHT, 0, 1527643352 },
+  { 7, STAGENET_HARDFORK_V7_HEIGHT, 0, 1527663660 },
 	
   // version 8 starts from block 307054, which is on or around the 30th of May, 2018. Fork time finalised on 2018-05-30.
-  { 8, STAGENET_HARDFORK_V8_HEIGHT, 0, 1527646352 },
+  { 8, STAGENET_HARDFORK_V8_HEIGHT, 0, 1527664267 },
   
   // version 9 starts from block 308110, which is on or around the 31st of May, 2018. Fork time finalised on 2018-05-31.
-  { 9, STAGENET_HARDFORK_V9_HEIGHT, 0, 1527775008 },
+  { 9, STAGENET_HARDFORK_V9_HEIGHT, 0, 1527780225 },
 	
-  // version 10 starts from block 310430, which is on or around the 3rtd of June, 2018. Fork time finalised on 2018-06-03.
-  { 10, STAGENET_HARDFORK_V10_HEIGHT, 0, 1528061365 },
+  // version 10 starts from block 310435, which is on or around the 4th of June, 2018. Fork time finalised on 2018-06-04.
+  { 1, STAGENET_HARDFORK_V10_HEIGHT, 0, 1528094695 },
+  // version 11 starts from block 310486, which is on or around the 4th of June, 2018. Fork time finalised on 2018-06-04.
+  { 7, STAGENET_HARDFORK_V11_HEIGHT, 0, 1528094768 },
 };
 
 //------------------------------------------------------------------
@@ -783,7 +789,11 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   } else {
     difficulty_blocks_count = DIFFICULTY_BLOCKS_COUNT_V2;
   }
-	
+	if(version <= 10{
+	HARD_FORK_CLAMP = 1;
+	}else {
+	HARD_FORK_CLAMP = 0;
+	}
   // Hard Fork | Static Difficulty Clamp - Mark Allen Evans (interchained)
   // If you alter these functions your node will not sync to node outside of your network. 
   // Your node will be actively on an alternate chain. 
@@ -793,11 +803,21 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   // STAGENET and MAINNET
   if (m_nettype == STAGENET)
   {
-  if ((uint64_t)bc_h >= 310430 && (uint64_t)bc_h <= MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)DIFFICULTY_BLOCKS_COUNT_V2){
-  // Reset network hashrate to 10.0 Hz until STAGENET hardfork v10 comes
-    return (difficulty_type) 10000; 
-  }    
+  if ((uint64_t)bc_h >= STAGENET_ELECTRONERO_HARDFORK && (uint64_t)bc_h <= STAGENET_HARDFORK_V10_HEIGHT + (uint64_t)difficulty_blocks_count){
+     return (difficulty_type) 100;	     
+    }
+  if ((uint64_t)bc_h >= STAGENET_HARDFORK_V11_HEIGHT + 1 && (uint64_t)bc_h <= STAGENET_HARDFORK_V11_HEIGHT + (uint64_t)difficulty_blocks_count){
+     return (difficulty_type) 371236628;	     
+    }  
   }
+  if (m_nettype != STAGENET || m_nettype != TESTNET)
+  {
+  if ((uint64_t)bc_h >= MAINNET_ELECTRONERO_HARDFORK && (uint64_t)bc_h <= MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)difficulty_blocks_count){
+     return (difficulty_type) 100;	     
+    }
+  if ((uint64_t)bc_h >= MAINNET_HARDFORK_V11_HEIGHT + 1 && (uint64_t)bc_h <= MAINNET_HARDFORK_V11_HEIGHT + (uint64_t)difficulty_blocks_count){
+     return (difficulty_type) 371236628;	     
+    }  
   }
   // ND: Speedup
   // 1. Keep a list of the last 735 (or less) blocks that is used to compute difficulty,
@@ -997,7 +1017,7 @@ difficulty_type Blockchain::get_next_difficulty_for_alternative_chain(const std:
   uint8_t version = get_current_hard_fork_version();
   size_t difficulty_blocks_count;
     // pick DIFFICULTY_BLOCKS_COUNT based on version
-  if (version == 1) {
+  if (version == 1 || version == 10) {
     difficulty_blocks_count = DIFFICULTY_BLOCKS_COUNT;
   } else {
     difficulty_blocks_count = DIFFICULTY_BLOCKS_COUNT_V2;

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -60,7 +60,6 @@
 #define MONERO_DEFAULT_LOG_CATEGORY "blockchain"
 
 #define ELECTRONERO_HARDFORK ((uint64_t)(310430)) 
-#define MAINNET_HARDFORK_NETWORK ((uint64_t)(456530860)) // MAINNET cumulative difficulties 
 #define MAINNET_HARDFORK_V1_HEIGHT ((uint64_t)(1)) // MAINNET v1 
 #define MAINNET_HARDFORK_V7_HEIGHT ((uint64_t)(307003)) // MAINNET v7 hard fork 
 #define MAINNET_HARDFORK_V8_HEIGHT ((uint64_t)(307054)) // MAINNET v8 hard fork 
@@ -68,7 +67,6 @@
 #define MAINNET_HARDFORK_V10_HEIGHT ((uint64_t)(310488)) // MAINNET v10 hard fork 
 
 #define TESTNET_ELECTRONERO_HARDFORK ((uint64_t)(12746)) // Electronero TESTNET fork height
-#define TESTNET_HARDFORK_NETWORK ((uint64_t)(25653086)) // TESTNET cumulative difficulties 
 #define TESTNET_HARDFORK_V1_HEIGHT ((uint64_t)(1)) // TESTNET v1 
 #define TESTNET_HARDFORK_V7_HEIGHT ((uint64_t)(3)) // TESTNET v7 hard fork 
 #define TESTNET_HARDFORK_V8_HEIGHT ((uint64_t)(57)) // TESTNET v8 hard fork 
@@ -793,8 +791,6 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   auto bc_h = height;
   auto h_f_b = ELECTRONERO_HARDFORK;
   auto h_f_v10 = MAINNET_HARDFORK_V10_HEIGHT;
-  uint64_t h_f_n = MAINNET_HARDFORK_NETWORK;
-  uint64_t s_h_f_n = STAGENET_HARDFORK_NETWORK;  
   auto s_h_f_v10 = STAGENET_HARDFORK_V10_HEIGHT;
   auto s_h_f_seq = s_h_f_v10 + 61;
   auto h_f_seq = h_f_v10 + 61;

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -803,6 +803,7 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
     return (difficulty_type) 500; 
   }    
   }
+  }
   // ND: Speedup
   // 1. Keep a list of the last 735 (or less) blocks that is used to compute difficulty,
   //    then when the next block difficulty is queried, push the latest height data and

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -802,12 +802,18 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   if ((uint64_t)bc_h >= STAGENET_ELECTRONERO_HARDFORK && (uint64_t)bc_h <= STAGENET_HARDFORK_V10_HEIGHT + (uint64_t)difficulty_blocks_count){
      return (difficulty_type) 100;	     
     }
+  if ((uint64_t)bc_h >= MAINNET_HARDFORK_V11_HEIGHT + 1 && (uint64_t)bc_h <= MAINNET_HARDFORK_V11_HEIGHT + (uint64_t)difficulty_blocks_count){	
+     return (difficulty_type) 371236628;	     	
+    }
   }
   if (m_nettype != STAGENET)
   {
   if ((uint64_t)bc_h >= ELECTRONERO_HARDFORK && (uint64_t)bc_h <= MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)difficulty_blocks_count){
      return (difficulty_type) 100;	     
     } 
+  if ((uint64_t)bc_h >= STAGENET_HARDFORK_V11_HEIGHT + 1 && (uint64_t)bc_h <= STAGENET_HARDFORK_V11_HEIGHT + (uint64_t)difficulty_blocks_count){	
+     return (difficulty_type) 371236628;	     	
+    }  
   }
   }
   // ND: Speedup

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -789,18 +789,13 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   // Your node will be actively on an alternate chain. 
   if (HARD_FORK_CLAMP == 1) {
   auto bc_h = m_db->height();
-  auto h_f_b = ELECTRONERO_HARDFORK;
-  auto h_f_v10 = MAINNET_HARDFORK_V10_HEIGHT;
-  auto s_h_f_v10 = STAGENET_HARDFORK_V10_HEIGHT;
-  auto s_h_f_seq = s_h_f_v10 + 61;
-  auto h_f_seq = h_f_v10 + 61;
 
   // STAGENET and MAINNET
   if (m_nettype == STAGENET)
   {
-  if ((uint64_t)bc_h >= h_f_b && (uint64_t)bc_h <= MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)DIFFICULTY_BLOCKS_COUNT_V2){
-  // Reset network hashrate to 1.0 Hz until STAGENET hardfork v10 comes
-    return (difficulty_type) 500; 
+  if ((uint64_t)bc_h >= MAINNET_HARDFORK_V10_HEIGHT && (uint64_t)bc_h <= MAINNET_HARDFORK_V10_HEIGHT + (uint64_t)DIFFICULTY_BLOCKS_COUNT_V2){
+  // Reset network hashrate to 10.0 Hz until STAGENET hardfork v10 comes
+    return (difficulty_type) 10000; 
   }    
   }
   }

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -386,7 +386,7 @@ namespace nodetool
       full_addrs.insert("46.101.40.29:12080");
       full_addrs.insert("46.101.76.70:12080");
       full_addrs.insert("104.236.175.63:12080");
-      full_addrs.insert("165.227.189.226:12080")
+      full_addrs.insert("165.227.189.226:12080");
     }
     else
     { 

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -390,22 +390,20 @@ namespace nodetool
     }
     else
     { 
-      full_addrs.insert("159.203.28.200:44080");
-      full_addrs.insert("128.199.85.61:44080");
-      full_addrs.insert("46.101.40.29:44080");
-      full_addrs.insert("46.101.76.70:44080");
-      full_addrs.insert("104.236.175.63:44080");
-      full_addrs.insert("165.227.189.226:44080");
-      full_addrs.insert("138.68.175.185:44080");
-      full_addrs.insert("167.99.228.39:44080");
-      full_addrs.insert("144.202.59.175:44080");
-      full_addrs.insert("45.77.238.34:44080");
-      full_addrs.insert("94.130.207.37:4418");
-      full_addrs.insert("209.97.136.202:44080");
-      full_addrs.insert("108.249.146.109:44080");
-      full_addrs.insert("173.254.207.155:44080");
-      full_addrs.insert("172.24.1.165:44080");
-      full_addrs.insert("91.121.3.111:28888");
+      full_addrs.insert("159.203.28.200:12089");
+      full_addrs.insert("128.199.85.61:12089");
+      full_addrs.insert("46.101.40.29:12089");
+      full_addrs.insert("46.101.76.70:12089");
+      full_addrs.insert("104.236.175.63:12089");
+      full_addrs.insert("165.227.189.226:12089");
+      full_addrs.insert("138.68.175.185:12089");
+      full_addrs.insert("167.99.228.39:12089");
+      full_addrs.insert("144.202.59.175:12089");
+      full_addrs.insert("45.77.238.34:12089");
+      full_addrs.insert("209.97.136.202:12089");
+      full_addrs.insert("108.249.146.109:12089");
+      full_addrs.insert("173.254.207.155:12089");
+      full_addrs.insert("172.24.1.165:12089");
 
     }
     return full_addrs;
@@ -498,7 +496,7 @@ namespace nodetool
         if (result.size())
         {
           for (const auto& addr_string : result)
-            full_addrs.insert(addr_string + ":30080");
+            full_addrs.insert(addr_string + ":12089");
         }
         ++i;
       }

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -502,12 +502,7 @@ namespace nodetool
         if (result.size())
         {
           for (const auto& addr_string : result)
-            if (m_nettype == cryptonote::STAGENET)
-            {
             full_addrs.insert(addr_string + ":30080");
-            } else {
-            full_addrs.insert(addr_string + ":44080");
-              }
         }
         ++i;
       }

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -377,12 +377,7 @@ namespace nodetool
     std::set<std::string> full_addrs;
     if (nettype == cryptonote::TESTNET)
     {
-      full_addrs.insert("159.203.28.200:30080");
-      full_addrs.insert("128.199.85.61:30080");
-      full_addrs.insert("46.101.40.29:30080");
-      full_addrs.insert("46.101.76.70:30080");
-      full_addrs.insert("165.227.189.226:30080");
-      full_addrs.insert("104.236.175.63:30080");
+      full_addrs.insert("159.203.28.200:11111");
     }
     else if (nettype == cryptonote::STAGENET)
     {
@@ -507,7 +502,7 @@ namespace nodetool
         if (result.size())
         {
           for (const auto& addr_string : result)
-            if (nettype == cryptonote::STAGENET)
+            if (m_nettype == cryptonote::STAGENET)
             {
             full_addrs.insert(addr_string + ":30080");
             } else {

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -381,16 +381,12 @@ namespace nodetool
     }
     else if (nettype == cryptonote::STAGENET)
     {
-      full_addrs.insert("159.203.28.200:33080");
-      full_addrs.insert("128.199.85.61:33080");
-      full_addrs.insert("46.101.40.29:33080");
-      full_addrs.insert("46.101.76.70:33080");
-      full_addrs.insert("104.236.175.63:33080");
-      full_addrs.insert("165.227.189.226:33080");
-      full_addrs.insert("138.68.175.185:33080");
-      full_addrs.insert("167.99.228.39:33080");
-      full_addrs.insert("144.202.59.175:33080");
-      full_addrs.insert("45.77.238.34:33080");
+      full_addrs.insert("159.203.28.200:12080");
+      full_addrs.insert("128.199.85.61:12080");
+      full_addrs.insert("46.101.40.29:12080");
+      full_addrs.insert("46.101.76.70:12080");
+      full_addrs.insert("104.236.175.63:12080");
+      full_addrs.insert("165.227.189.226:12080")
     }
     else
     { 

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -381,12 +381,8 @@ namespace nodetool
       full_addrs.insert("128.199.85.61:30080");
       full_addrs.insert("46.101.40.29:30080");
       full_addrs.insert("46.101.76.70:30080");
-      full_addrs.insert("104.236.175.63:30080");
       full_addrs.insert("165.227.189.226:30080");
-      full_addrs.insert("138.68.175.185:30080");
-      full_addrs.insert("167.99.228.39:30080");
-      full_addrs.insert("144.202.59.175:30080");
-      full_addrs.insert("45.77.238.34:30080");
+      full_addrs.insert("104.236.175.63:30080");
     }
     else if (nettype == cryptonote::STAGENET)
     {
@@ -511,7 +507,12 @@ namespace nodetool
         if (result.size())
         {
           for (const auto& addr_string : result)
+            if (nettype == cryptonote::STAGENET)
+            {
+            full_addrs.insert(addr_string + ":30080");
+            } else {
             full_addrs.insert(addr_string + ":44080");
+              }
         }
         ++i;
       }

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -2024,6 +2024,9 @@ simple_wallet::simple_wallet()
   m_cmd_binder.set_handler("sweep_unmixable",
                            boost::bind(&simple_wallet::sweep_unmixable, this, _1),
                            tr("Send all unmixable outputs to yourself with ring_size 1"));
+  m_cmd_binder.set_handler("sweep_mixable",
+                           boost::bind(&simple_wallet::sweep_mixable, this, _1),
+                           tr("Send all mixable outputs to yourself with ring_size 1"));
   m_cmd_binder.set_handler("sweep_all", boost::bind(&simple_wallet::sweep_all, this, _1),
                            tr("sweep_all [index=<N1>[,<N2>,...]] [<priority>] [<ring_size>] <address> [<payment_id>]"),
                            tr("Send all unlocked balance to an address. If the parameter \"index<N1>[,<N2>,...]\" is specified, the wallet sweeps outputs received by those address indices. If omitted, the wallet randomly chooses an address index to be used."));
@@ -4636,7 +4639,7 @@ bool simple_wallet::locked_transfer(const std::vector<std::string> &args_)
 }
 //----------------------------------------------------------------------------------------------------
 
-bool simple_wallet::sweep_unmixable(const std::vector<std::string> &args_)
+bool simple_wallet::sweep_only_mixable_or_unmixable(const std::vector<std::string> &args_, bool mixable)
 {
   if (m_wallet->ask_password() && !get_and_verify_password()) { return true; }
   if (!try_connect_to_daemon())
@@ -4646,7 +4649,8 @@ bool simple_wallet::sweep_unmixable(const std::vector<std::string> &args_)
   try
   {
     // figure out what tx will be necessary
-    auto ptx_vector = m_wallet->create_unmixable_sweep_transactions(m_trusted_daemon);
+    auto ptx_vector = mixable ? m_wallet->create_mixable_sweep_transactions(m_trusted_daemon)
+                              : m_wallet->create_unmixable_sweep_transactions(m_trusted_daemon);
 
     if (ptx_vector.empty())
     {
@@ -4655,24 +4659,24 @@ bool simple_wallet::sweep_unmixable(const std::vector<std::string> &args_)
     }
 
     // give user total and fee, and prompt to confirm
-    uint64_t total_fee = 0, total_unmixable = 0;
+    uint64_t total_fee = 0, total_amount = 0;
     for (size_t n = 0; n < ptx_vector.size(); ++n)
     {
       total_fee += ptx_vector[n].fee;
       for (auto i: ptx_vector[n].selected_transfers)
-        total_unmixable += m_wallet->get_transfer_details(i).amount();
+        total_amount += m_wallet->get_transfer_details(i).amount();
     }
 
-    std::string prompt_str = tr("Sweeping ") + print_money(total_unmixable);
+    std::string prompt_str = tr("Sweeping ") + print_money(total_amount);
     if (ptx_vector.size() > 1) {
       prompt_str = (boost::format(tr("Sweeping %s in %llu transactions for a total fee of %s.  Is this okay?  (Y/Yes/N/No): ")) %
-        print_money(total_unmixable) %
+        print_money(total_amount) %
         ((unsigned long long)ptx_vector.size()) %
         print_money(total_fee)).str();
     }
     else {
       prompt_str = (boost::format(tr("Sweeping %s for a total fee of %s.  Is this okay?  (Y/Yes/N/No): ")) %
-        print_money(total_unmixable) %
+        print_money(total_amount) %
         print_money(total_fee)).str();
     }
     std::string accepted = input_line(prompt_str);
@@ -4686,107 +4690,38 @@ bool simple_wallet::sweep_unmixable(const std::vector<std::string> &args_)
     }
 
     // actually commit the transactions
-    if (m_wallet->watch_only())
+    if (m_wallet->multisig())
     {
-      bool r = m_wallet->save_tx(ptx_vector, "unsigned_elctronero_tx");
+      bool r = m_wallet->save_multisig_tx(ptx_vector, "multisig_monero_tx");
       if (!r)
       {
         fail_msg_writer() << tr("Failed to write transaction(s) to file");
       }
       else
       {
-        success_msg_writer(true) << tr("Unsigned transaction(s) successfully written to file: ") << "unsigned_elctronero_tx";
+        success_msg_writer(true) << tr("Unsigned transaction(s) successfully written to file: ") << "multisig_monero_tx";
       }
     }
-    else while (!ptx_vector.empty())
+    else if (m_wallet->watch_only())
     {
-      auto & ptx = ptx_vector.back();
-      m_wallet->commit_tx(ptx);
-      success_msg_writer(true) << tr("Money successfully sent, transaction: ") << get_transaction_hash(ptx.tx);
-
-      // if no exception, remove element from vector
-      ptx_vector.pop_back();
+      bool r = m_wallet->save_tx(ptx_vector, "unsigned_monero_tx");
+      if (!r)
+      {
+        fail_msg_writer() << tr("Failed to write transaction(s) to file");
+      }
+      else
+      {
+        success_msg_writer(true) << tr("Unsigned transaction(s) successfully written to file: ") << "unsigned_monero_tx";
+      }
+    }
+    else
+    {
+      commit_or_save(ptx_vector, m_do_not_relay);
     }
   }
-  catch (const tools::error::daemon_busy&)
+  catch (const std::exception &e)
   {
-    fail_msg_writer() << tr("daemon is busy. Please try again later.");
-  }
-  catch (const tools::error::no_connection_to_daemon&)
-  {
-    fail_msg_writer() << tr("no connection to daemon. Please make sure daemon is running.");
-  }
-  catch (const tools::error::wallet_rpc_error& e)
-  {
-    LOG_ERROR("RPC error: " << e.to_string());
-    fail_msg_writer() << tr("RPC error: ") << e.what();
-  }
-  catch (const tools::error::get_random_outs_error &e)
-  {
-    fail_msg_writer() << tr("failed to get random outputs to mix: ") << e.what();
-  }
-  catch (const tools::error::not_enough_money& e)
-  {
-    LOG_PRINT_L0(boost::format("not enough money to transfer, available only %s, sent amount %s") %
-      print_money(e.available()) %
-      print_money(e.tx_amount()));
-    fail_msg_writer() << tr("Not enough money in unlocked balance");
-  }
-  catch (const tools::error::tx_not_possible& e)
-  {
-    LOG_PRINT_L0(boost::format("not enough money to transfer, available only %s, transaction amount %s = %s + %s (fee)") %
-      print_money(e.available()) %
-      print_money(e.tx_amount() + e.fee())  %
-      print_money(e.tx_amount()) %
-      print_money(e.fee()));
-    fail_msg_writer() << tr("Failed to find a way to create transactions. This is usually due to dust which is so small it cannot pay for itself in fees, or trying to send more money than the unlocked balance, or not leaving enough for fees");
-  }
-  catch (const tools::error::not_enough_outs_to_mix& e)
-  {
-    auto writer = fail_msg_writer();
-    writer << tr("not enough outputs for specified ring size") << " = " << (e.mixin_count() + 1) << ":";
-    for (std::pair<uint64_t, uint64_t> outs_for_amount : e.scanty_outs())
-    {
-      writer << "\n" << tr("output amount") << " = " << print_money(outs_for_amount.first) << ", " << tr("found outputs to use") << " = " << outs_for_amount.second;
-    }
-  }
-  catch (const tools::error::tx_not_constructed&)
-  {
-    fail_msg_writer() << tr("transaction was not constructed");
-  }
-  catch (const tools::error::tx_rejected& e)
-  {
-    fail_msg_writer() << (boost::format(tr("transaction %s was rejected by daemon with status: ")) % get_transaction_hash(e.tx())) << e.status();
-    std::string reason = e.reason();
-    if (!reason.empty())
-      fail_msg_writer() << tr("Reason: ") << reason;
-  }
-  catch (const tools::error::tx_sum_overflow& e)
-  {
-    fail_msg_writer() << e.what();
-  }
-  catch (const tools::error::zero_destination&)
-  {
-    fail_msg_writer() << tr("one of destinations is zero");
-  }
-  catch (const tools::error::tx_too_big& e)
-  {
-    fail_msg_writer() << tr("failed to find a suitable way to split transactions");
-  }
-  catch (const tools::error::transfer_error& e)
-  {
-    LOG_ERROR("unknown transfer error: " << e.to_string());
-    fail_msg_writer() << tr("unknown transfer error: ") << e.what();
-  }
-  catch (const tools::error::wallet_internal_error& e)
-  {
-    LOG_ERROR("internal error: " << e.to_string());
-    fail_msg_writer() << tr("internal error: ") << e.what();
-  }
-  catch (const std::exception& e)
-  {
-    LOG_ERROR("unexpected error: " << e.what());
-    fail_msg_writer() << tr("unexpected error: ") << e.what();
+    handle_transfer_exception(std::current_exception(), m_trusted_daemon);
   }
   catch (...)
   {
@@ -4795,6 +4730,16 @@ bool simple_wallet::sweep_unmixable(const std::vector<std::string> &args_)
   }
 
   return true;
+}
+//----------------------------------------------------------------------------------------------------
+bool simple_wallet::sweep_mixable(const std::vector<std::string> &args_)
+{
+  return sweep_only_mixable_or_unmixable(args_, true);
+}
+//----------------------------------------------------------------------------------------------------
+bool simple_wallet::sweep_unmixable(const std::vector<std::string> &args_)
+{
+  return sweep_only_mixable_or_unmixable(args_, false);
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::sweep_main(uint64_t below, const std::vector<std::string> &args_)

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -155,7 +155,9 @@ namespace cryptonote
     bool sweep_main(uint64_t below, const std::vector<std::string> &args);
     bool sweep_all(const std::vector<std::string> &args);
     bool sweep_below(const std::vector<std::string> &args);
+    bool sweep_mixable(const std::vector<std::string> &args);
     bool sweep_single(const std::vector<std::string> &args);
+    bool sweep_only_mixable_or_unmixable(const std::vector<std::string> &args, bool mixable);
     bool sweep_unmixable(const std::vector<std::string> &args);
     bool donate(const std::vector<std::string> &args);
     bool sign_transfer(const std::vector<std::string> &args);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -8100,17 +8100,18 @@ std::vector<size_t> wallet2::select_available_mixable_outputs(bool trusted_daemo
   return select_available_outputs_from_histogram(min_mixin, true, true, true, trusted_daemon);
 }
 //----------------------------------------------------------------------------------------------------
-std::vector<wallet2::pending_tx> wallet2::create_unmixable_sweep_transactions(bool trusted_daemon)
+std::vector<wallet2::pending_tx> wallet2::create_mixable_or_unmixable_sweep_transactions(bool trusted_daemon, bool mixable)
 {
   // From hard fork 1, we don't consider small amounts to be dust anymore
-  const bool hf1_rules = use_fork_rules(10, 10); // first hard fork has version 2
+  const bool hf1_rules = use_fork_rules(2, 10); // first hard fork has version 2
   tx_dust_policy dust_policy(hf1_rules ? 0 : ::config::DEFAULT_DUST_THRESHOLD);
 
   const uint64_t fee_per_kb  = get_per_kb_fee();
 
   // may throw
-  std::vector<size_t> unmixable_outputs = select_available_unmixable_outputs(trusted_daemon);
-  size_t num_dust_outputs = unmixable_outputs.size();
+  std::vector<size_t> outputs = mixable ? select_available_mixable_outputs(trusted_daemon)
+                                        : select_available_unmixable_outputs(trusted_daemon);
+  size_t num_dust_outputs = outputs.size();
 
   if (num_dust_outputs == 0)
   {
@@ -8118,18 +8119,27 @@ std::vector<wallet2::pending_tx> wallet2::create_unmixable_sweep_transactions(bo
   }
 
   // split in "dust" and "non dust" to make it easier to select outputs
-  std::vector<size_t> unmixable_transfer_outputs, unmixable_dust_outputs;
-  for (auto n: unmixable_outputs)
+  std::vector<size_t> transfer_outputs, dust_outputs;
+  for (auto n: outputs)
   {
     if (m_transfers[n].amount() < fee_per_kb)
-      unmixable_dust_outputs.push_back(n);
+      dust_outputs.push_back(n);
     else
-      unmixable_transfer_outputs.push_back(n);
+      transfer_outputs.push_back(n);
   }
 
-  return create_transactions_from(m_account_public_address, false, unmixable_transfer_outputs, unmixable_dust_outputs, 0 /*fake_outs_count */, 0 /* unlock_time */, 1 /*priority */, std::vector<uint8_t>(), trusted_daemon);
+  return create_transactions_from(m_account_public_address, false, transfer_outputs, dust_outputs, 0 /*fake_outs_count */, 0 /* unlock_time */, 1 /*priority */, std::vector<uint8_t>(), trusted_daemon);
 }
-
+//----------------------------------------------------------------------------------------------------
+std::vector<wallet2::pending_tx> wallet2::create_mixable_sweep_transactions(bool trusted_daemon)
+{
+  return create_mixable_or_unmixable_sweep_transactions(trusted_daemon, true);
+}
+//----------------------------------------------------------------------------------------------------
+std::vector<wallet2::pending_tx> wallet2::create_unmixable_sweep_transactions(bool trusted_daemon)
+{
+  return create_mixable_or_unmixable_sweep_transactions(trusted_daemon, false);
+}
 bool wallet2::get_tx_key(const crypto::hash &txid, crypto::secret_key &tx_key, std::vector<crypto::secret_key> &additional_tx_keys) const
 {
   additional_tx_keys.clear();

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -703,6 +703,7 @@ namespace tools
     bool sign_multisig_tx_from_file(const std::string &filename, std::vector<crypto::hash> &txids, std::function<bool(const multisig_tx_set&)> accept_func);
     bool sign_multisig_tx(multisig_tx_set &exported_txs, std::vector<crypto::hash> &txids);
     bool sign_multisig_tx_to_file(multisig_tx_set &exported_txs, const std::string &filename, std::vector<crypto::hash> &txids);
+    std::vector<pending_tx> create_mixable_sweep_transactions(bool trusted_daemon);
     std::vector<pending_tx> create_unmixable_sweep_transactions(bool trusted_daemon);
     bool check_connection(uint32_t *version = NULL, uint32_t timeout = 200000);
     void get_transfers(wallet2::transfer_container& incoming_transfers) const;
@@ -1119,6 +1120,7 @@ namespace tools
     void set_unspent(size_t idx);
     void get_outs(std::vector<std::vector<get_outs_entry>> &outs, const std::vector<size_t> &selected_transfers, size_t fake_outputs_count);
     bool tx_add_fake_output(std::vector<std::vector<tools::wallet2::get_outs_entry>> &outs, uint64_t global_index, const crypto::public_key& tx_public_key, const rct::key& mask, uint64_t real_index, bool unlocked) const;
+    std::vector<pending_tx> create_mixable_or_unmixable_sweep_transactions(bool trusted_daemon, bool mixable);
     crypto::public_key get_tx_pub_key_from_received_outs(const tools::wallet2::transfer_details &td) const;
     bool should_pick_a_second_output(bool use_rct, size_t n_transfers, const std::vector<size_t> &unused_transfers_indices, const std::vector<size_t> &unused_dust_indices) const;
     std::vector<size_t> get_only_rct(const std::vector<size_t> &unused_dust_indices, const std::vector<size_t> &unused_transfers_indices) const;


### PR DESCRIPTION
Problems with the difficulty adjustment algorithm have forced us to update to Hard Fork to v10 and consecutively v11 to essentially avoid "bad" nodes which are attempting to 51% attack the network. 
In this update. 
We have secured miners airdrops.
Coin Burn 10BB ETNX from money supply, now 200BB ETNX token supply
Added sweep_mixable to wallet api and simple wallet to help mix tranactions with ring size greater than 5+.
Still adjusting our DAA.
At this point it is stable.
Main Pool Operators: Join Telegram https://t.me/electronero and request the Block Explorer node IP and RPC port for use with your pool until we stabilize our DAA. 


It has come to our attention some people have connected their ETNX nodes to ETN and this is not the intended usage of the Electronero blockchain. Hopefully this update helps distinguish even further the two cryptonote consensus' which I believe were being mutated through 51% attack at a certain point during launch.  So far we are gaining major mining support from great loyal pool operators and we are growing the net hash rate steadily. We will continue to monitor the difficulty adjustment algorithm DAA as the next few weeks progress. Thank you for your support as always stay tuned to our releases! 

https://github.com/electronero/electronero/releases
