### PR TITLE
[CMC][NODE][API] Add already_generated_coins to map for /getcoins call 

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1565,7 +1565,7 @@ namespace cryptonote
   //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_get_info_json(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res, epee::json_rpc::error& error_resp)
   {
-    PERF_TIMER(on_get_info_json);
+    PERF_TIMER(on_get_coins_json);
     bool r;
     if (use_bootstrap_daemon_if_necessary<COMMAND_RPC_GET_INFO>(invoke_http_mode::JON_RPC, "get_info", req, res, r))
     {

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1554,7 +1554,7 @@ namespace cryptonote
    //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_get_coins_json(const COMMAND_RPC_GET_COINS::request& req, COMMAND_RPC_GET_COINS::response& res, epee::json_rpc::error& error_resp)
   {
-    PERF_TIMER(on_get_info_json);
+    PERF_TIMER(on_get_coins_json);
 
     // response = already_generated_coins  
     uint64_t height = m_core.get_current_blockchain_height();
@@ -1565,7 +1565,7 @@ namespace cryptonote
   //------------------------------------------------------------------------------------------------------------------------------
   bool core_rpc_server::on_get_info_json(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res, epee::json_rpc::error& error_resp)
   {
-    PERF_TIMER(on_get_coins_json);
+    PERF_TIMER(on_get_info_json);
     bool r;
     if (use_bootstrap_daemon_if_necessary<COMMAND_RPC_GET_INFO>(invoke_http_mode::JON_RPC, "get_info", req, res, r))
     {

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -210,25 +210,13 @@ namespace cryptonote
     return true;
   }
  //------------------------------------------------------------------------------------------------------------------------------
-  bool core_rpc_server::on_get_coins(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res)
+  bool core_rpc_server::on_get_coins(const COMMAND_RPC_GET_COINS::request& req, COMMAND_RPC_GET_COINS::response& res)
   {
-    PERF_TIMER(on_get_info);
-    bool r;
-    if (use_bootstrap_daemon_if_necessary<COMMAND_RPC_GET_INFO>(invoke_http_mode::JON, "/getinfo", req, res, r))
-    {
-      res.bootstrap_daemon_address = m_bootstrap_daemon_address;
-      crypto::hash top_hash;
-      m_core.get_blockchain_top(res.height_without_bootstrap, top_hash);
-      ++res.height_without_bootstrap; // turn top block height into blockchain height
-      res.was_bootstrap_ever_used = true;
-      return r;
-    }
+    PERF_TIMER(on_get_coins);
 
-    crypto::hash top_hash;
-    m_core.get_blockchain_top(res.height, top_hash);
-    ++res.height; // turn top block height into blockchain height
     // response = already_generated_coins  
-    res = m_core.get_blockchain_storage().get_db().get_block_already_generated_coins(res.height - 1);
+    uint64_t height = m_core.get_current_blockchain_height();
+    res.already_generated_coins = m_core.get_blockchain_storage().get_db().get_block_already_generated_coins(height - 1);
 
     return true;
   }
@@ -1564,26 +1552,13 @@ namespace cryptonote
     return true;
   }
    //------------------------------------------------------------------------------------------------------------------------------
-  bool core_rpc_server::on_get_coins_json(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res)
+  bool core_rpc_server::on_get_coins_json(const COMMAND_RPC_GET_COINS::request& req, COMMAND_RPC_GET_COINS::response& res)
   {
     PERF_TIMER(on_get_info_json);
-    bool r;
-    if (use_bootstrap_daemon_if_necessary<COMMAND_RPC_GET_INFO>(invoke_http_mode::JON, "/get_info", req, res, r))
-    {
-      res.bootstrap_daemon_address = m_bootstrap_daemon_address;
-      crypto::hash top_hash;
-      m_core.get_blockchain_top(res.height_without_bootstrap, top_hash);
-      ++res.height_without_bootstrap; // turn top block height into blockchain height
-      res.was_bootstrap_ever_used = true;
-      return r;
-    }
 
-    crypto::hash top_hash;
-    m_core.get_blockchain_top(res.height, top_hash);
-    ++res.height; // turn top block height into blockchain height
-	  
     // response = already_generated_coins  
-    res = m_core.get_blockchain_storage().get_db().get_block_already_generated_coins(res.height - 1);
+    uint64_t height = m_core.get_current_blockchain_height();
+    res.already_generated_coins = m_core.get_blockchain_storage().get_db().get_block_already_generated_coins(height - 1);
 
     return true;
   }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1552,7 +1552,7 @@ namespace cryptonote
     return true;
   }
    //------------------------------------------------------------------------------------------------------------------------------
-  bool core_rpc_server::on_get_coins_json(const COMMAND_RPC_GET_COINS::request& req, COMMAND_RPC_GET_COINS::response& res)
+  bool core_rpc_server::on_get_coins_json(const COMMAND_RPC_GET_COINS::request& req, COMMAND_RPC_GET_COINS::response& res, epee::json_rpc::error& error_resp)
   {
     PERF_TIMER(on_get_info_json);
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -210,7 +210,7 @@ namespace cryptonote
     return true;
   }
  //------------------------------------------------------------------------------------------------------------------------------
-  bool core_rpc_server::on_get_coins(const COMMAND_RPC_GET_COINS::request& req, COMMAND_RPC_GET_COINS::response& res)
+  bool core_rpc_server::on_get_coins(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res)
   {
     PERF_TIMER(on_get_info);
     bool r;
@@ -229,9 +229,7 @@ namespace cryptonote
     ++res.height; // turn top block height into blockchain height
     // response = already_generated_coins  
     res = m_core.get_blockchain_storage().get_db().get_block_already_generated_coins(res.height - 1);
-    {
-      boost::shared_lock<boost::shared_mutex> lock(m_bootstrap_daemon_mutex);
-    }
+
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -1583,11 +1581,10 @@ namespace cryptonote
     crypto::hash top_hash;
     m_core.get_blockchain_top(res.height, top_hash);
     ++res.height; // turn top block height into blockchain height
+	  
     // response = already_generated_coins  
     res = m_core.get_blockchain_storage().get_db().get_block_already_generated_coins(res.height - 1);
-    {
-      boost::shared_lock<boost::shared_mutex> lock(m_bootstrap_daemon_mutex);
-    }
+
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -206,8 +206,8 @@ namespace cryptonote
     bool on_get_block_headers_range(const COMMAND_RPC_GET_BLOCK_HEADERS_RANGE::request& req, COMMAND_RPC_GET_BLOCK_HEADERS_RANGE::response& res, epee::json_rpc::error& error_resp);
     bool on_get_block(const COMMAND_RPC_GET_BLOCK::request& req, COMMAND_RPC_GET_BLOCK::response& res, epee::json_rpc::error& error_resp);
     bool on_get_connections(const COMMAND_RPC_GET_CONNECTIONS::request& req, COMMAND_RPC_GET_CONNECTIONS::response& res, epee::json_rpc::error& error_resp);
-    bool on_get_info_json(const COMMAND_RPC_GET_COINS::request& req, COMMAND_RPC_GET_COINS::response& res, epee::json_rpc::error& error_resp);
-    bool on_get_coins_json(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res, epee::json_rpc::error& error_resp);
+    bool on_get_info_json(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res, epee::json_rpc::error& error_resp);
+    bool on_get_coins_json(const COMMAND_RPC_GET_COINS::request& req, COMMAND_RPC_GET_COINS::response& res, epee::json_rpc::error& error_resp);
     bool on_hard_fork_info(const COMMAND_RPC_HARD_FORK_INFO::request& req, COMMAND_RPC_HARD_FORK_INFO::response& res, epee::json_rpc::error& error_resp);
     bool on_set_bans(const COMMAND_RPC_SETBANS::request& req, COMMAND_RPC_SETBANS::response& res, epee::json_rpc::error& error_resp);
     bool on_get_bans(const COMMAND_RPC_GETBANS::request& req, COMMAND_RPC_GETBANS::response& res, epee::json_rpc::error& error_resp);

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -112,8 +112,8 @@ namespace cryptonote
       MAP_URI_AUTO_JON2_IF("/stop_daemon", on_stop_daemon, COMMAND_RPC_STOP_DAEMON, !m_restricted)
       MAP_URI_AUTO_JON2("/get_info", on_get_info, COMMAND_RPC_GET_INFO)
       MAP_URI_AUTO_JON2("/getinfo", on_get_info, COMMAND_RPC_GET_INFO)
-      MAP_URI_AUTO_JON2("/get_coins", on_get_coins, COMMAND_RPC_GET_COINS)
-      MAP_URI_AUTO_JON2("/getcoins", on_get_coins, COMMAND_RPC_GET_COINS)
+      MAP_URI_AUTO_JON2("/get_coins", on_get_coins, COMMAND_RPC_GET_INFO)
+      MAP_URI_AUTO_JON2("/getcoins", on_get_coins, COMMAND_RPC_GET_INFO)
       MAP_URI_AUTO_JON2("/get_limit", on_get_limit, COMMAND_RPC_GET_LIMIT)
       MAP_URI_AUTO_JON2_IF("/set_limit", on_set_limit, COMMAND_RPC_SET_LIMIT, !m_restricted)
       MAP_URI_AUTO_JON2_IF("/out_peers", on_out_peers, COMMAND_RPC_OUT_PEERS, !m_restricted)
@@ -143,7 +143,7 @@ namespace cryptonote
         MAP_JON_RPC_WE("getblock",                on_get_block,                 COMMAND_RPC_GET_BLOCK)
         MAP_JON_RPC_WE_IF("get_connections",     on_get_connections,            COMMAND_RPC_GET_CONNECTIONS, !m_restricted)
         MAP_JON_RPC_WE("get_info",               on_get_info_json,              COMMAND_RPC_GET_INFO)
-        MAP_JON_RPC_WE("get_coins",              on_get_coins_json,             COMMAND_RPC_GET_COINS)
+        MAP_JON_RPC_WE("get_coins",              on_get_coins_json,             COMMAND_RPC_GET_INFO)
         MAP_JON_RPC_WE("hard_fork_info",         on_hard_fork_info,             COMMAND_RPC_HARD_FORK_INFO)
         MAP_JON_RPC_WE_IF("set_bans",            on_set_bans,                   COMMAND_RPC_SETBANS, !m_restricted)
         MAP_JON_RPC_WE_IF("get_bans",            on_get_bans,                   COMMAND_RPC_GETBANS, !m_restricted)
@@ -207,7 +207,7 @@ namespace cryptonote
     bool on_get_block(const COMMAND_RPC_GET_BLOCK::request& req, COMMAND_RPC_GET_BLOCK::response& res, epee::json_rpc::error& error_resp);
     bool on_get_connections(const COMMAND_RPC_GET_CONNECTIONS::request& req, COMMAND_RPC_GET_CONNECTIONS::response& res, epee::json_rpc::error& error_resp);
     bool on_get_info_json(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res, epee::json_rpc::error& error_resp);
-    bool on_get_coins_json(const COMMAND_RPC_GET_COINS::request& req, COMMAND_RPC_GET_COINS::response& res, epee::json_rpc::error& error_resp);
+    bool on_get_coins_json(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res, epee::json_rpc::error& error_resp);
     bool on_hard_fork_info(const COMMAND_RPC_HARD_FORK_INFO::request& req, COMMAND_RPC_HARD_FORK_INFO::response& res, epee::json_rpc::error& error_resp);
     bool on_set_bans(const COMMAND_RPC_SETBANS::request& req, COMMAND_RPC_SETBANS::response& res, epee::json_rpc::error& error_resp);
     bool on_get_bans(const COMMAND_RPC_GETBANS::request& req, COMMAND_RPC_GETBANS::response& res, epee::json_rpc::error& error_resp);

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -112,6 +112,8 @@ namespace cryptonote
       MAP_URI_AUTO_JON2_IF("/stop_daemon", on_stop_daemon, COMMAND_RPC_STOP_DAEMON, !m_restricted)
       MAP_URI_AUTO_JON2("/get_info", on_get_info, COMMAND_RPC_GET_INFO)
       MAP_URI_AUTO_JON2("/getinfo", on_get_info, COMMAND_RPC_GET_INFO)
+      MAP_URI_AUTO_JON2("/get_coins", on_get_coins, COMMAND_RPC_GET_COINS)
+      MAP_URI_AUTO_JON2("/getcoins", on_get_coins, COMMAND_RPC_GET_COINS)
       MAP_URI_AUTO_JON2("/get_limit", on_get_limit, COMMAND_RPC_GET_LIMIT)
       MAP_URI_AUTO_JON2_IF("/set_limit", on_set_limit, COMMAND_RPC_SET_LIMIT, !m_restricted)
       MAP_URI_AUTO_JON2_IF("/out_peers", on_out_peers, COMMAND_RPC_OUT_PEERS, !m_restricted)
@@ -141,6 +143,7 @@ namespace cryptonote
         MAP_JON_RPC_WE("getblock",                on_get_block,                 COMMAND_RPC_GET_BLOCK)
         MAP_JON_RPC_WE_IF("get_connections",     on_get_connections,            COMMAND_RPC_GET_CONNECTIONS, !m_restricted)
         MAP_JON_RPC_WE("get_info",               on_get_info_json,              COMMAND_RPC_GET_INFO)
+        MAP_JON_RPC_WE("get_coins",              on_get_coins_json,             COMMAND_RPC_GET_COINS)
         MAP_JON_RPC_WE("hard_fork_info",         on_hard_fork_info,             COMMAND_RPC_HARD_FORK_INFO)
         MAP_JON_RPC_WE_IF("set_bans",            on_set_bans,                   COMMAND_RPC_SETBANS, !m_restricted)
         MAP_JON_RPC_WE_IF("get_bans",            on_get_bans,                   COMMAND_RPC_GETBANS, !m_restricted)
@@ -174,6 +177,7 @@ namespace cryptonote
     bool on_get_outs(const COMMAND_RPC_GET_OUTPUTS::request& req, COMMAND_RPC_GET_OUTPUTS::response& res);        
     bool on_get_random_rct_outs(const COMMAND_RPC_GET_RANDOM_RCT_OUTPUTS::request& req, COMMAND_RPC_GET_RANDOM_RCT_OUTPUTS::response& res);
     bool on_get_info(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res);
+    bool on_get_coins(const COMMAND_RPC_GET_COINS::request& req, COMMAND_RPC_GET_COINS::response& res);
     bool on_save_bc(const COMMAND_RPC_SAVE_BC::request& req, COMMAND_RPC_SAVE_BC::response& res);
     bool on_get_peer_list(const COMMAND_RPC_GET_PEER_LIST::request& req, COMMAND_RPC_GET_PEER_LIST::response& res);
     bool on_set_log_hash_rate(const COMMAND_RPC_SET_LOG_HASH_RATE::request& req, COMMAND_RPC_SET_LOG_HASH_RATE::response& res);
@@ -202,7 +206,8 @@ namespace cryptonote
     bool on_get_block_headers_range(const COMMAND_RPC_GET_BLOCK_HEADERS_RANGE::request& req, COMMAND_RPC_GET_BLOCK_HEADERS_RANGE::response& res, epee::json_rpc::error& error_resp);
     bool on_get_block(const COMMAND_RPC_GET_BLOCK::request& req, COMMAND_RPC_GET_BLOCK::response& res, epee::json_rpc::error& error_resp);
     bool on_get_connections(const COMMAND_RPC_GET_CONNECTIONS::request& req, COMMAND_RPC_GET_CONNECTIONS::response& res, epee::json_rpc::error& error_resp);
-    bool on_get_info_json(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res, epee::json_rpc::error& error_resp);
+    bool on_get_info_json(const COMMAND_RPC_GET_COINS::request& req, COMMAND_RPC_GET_COINS::response& res, epee::json_rpc::error& error_resp);
+    bool on_get_coins_json(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res, epee::json_rpc::error& error_resp);
     bool on_hard_fork_info(const COMMAND_RPC_HARD_FORK_INFO::request& req, COMMAND_RPC_HARD_FORK_INFO::response& res, epee::json_rpc::error& error_resp);
     bool on_set_bans(const COMMAND_RPC_SETBANS::request& req, COMMAND_RPC_SETBANS::response& res, epee::json_rpc::error& error_resp);
     bool on_get_bans(const COMMAND_RPC_GETBANS::request& req, COMMAND_RPC_GETBANS::response& res, epee::json_rpc::error& error_resp);

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -112,8 +112,8 @@ namespace cryptonote
       MAP_URI_AUTO_JON2_IF("/stop_daemon", on_stop_daemon, COMMAND_RPC_STOP_DAEMON, !m_restricted)
       MAP_URI_AUTO_JON2("/get_info", on_get_info, COMMAND_RPC_GET_INFO)
       MAP_URI_AUTO_JON2("/getinfo", on_get_info, COMMAND_RPC_GET_INFO)
-      MAP_URI_AUTO_JON2("/get_coins", on_get_coins, COMMAND_RPC_GET_INFO)
-      MAP_URI_AUTO_JON2("/getcoins", on_get_coins, COMMAND_RPC_GET_INFO)
+      MAP_URI_AUTO_JON2("/get_coins", on_get_coins, COMMAND_RPC_GET_COINS)
+      MAP_URI_AUTO_JON2("/getcoins", on_get_coins, COMMAND_RPC_GET_COINS)
       MAP_URI_AUTO_JON2("/get_limit", on_get_limit, COMMAND_RPC_GET_LIMIT)
       MAP_URI_AUTO_JON2_IF("/set_limit", on_set_limit, COMMAND_RPC_SET_LIMIT, !m_restricted)
       MAP_URI_AUTO_JON2_IF("/out_peers", on_out_peers, COMMAND_RPC_OUT_PEERS, !m_restricted)
@@ -143,7 +143,7 @@ namespace cryptonote
         MAP_JON_RPC_WE("getblock",                on_get_block,                 COMMAND_RPC_GET_BLOCK)
         MAP_JON_RPC_WE_IF("get_connections",     on_get_connections,            COMMAND_RPC_GET_CONNECTIONS, !m_restricted)
         MAP_JON_RPC_WE("get_info",               on_get_info_json,              COMMAND_RPC_GET_INFO)
-        MAP_JON_RPC_WE("get_coins",              on_get_coins_json,             COMMAND_RPC_GET_INFO)
+        MAP_JON_RPC_WE("get_coins",              on_get_coins_json,             COMMAND_RPC_GET_COINS)
         MAP_JON_RPC_WE("hard_fork_info",         on_hard_fork_info,             COMMAND_RPC_HARD_FORK_INFO)
         MAP_JON_RPC_WE_IF("set_bans",            on_set_bans,                   COMMAND_RPC_SETBANS, !m_restricted)
         MAP_JON_RPC_WE_IF("get_bans",            on_get_bans,                   COMMAND_RPC_GETBANS, !m_restricted)
@@ -207,7 +207,7 @@ namespace cryptonote
     bool on_get_block(const COMMAND_RPC_GET_BLOCK::request& req, COMMAND_RPC_GET_BLOCK::response& res, epee::json_rpc::error& error_resp);
     bool on_get_connections(const COMMAND_RPC_GET_CONNECTIONS::request& req, COMMAND_RPC_GET_CONNECTIONS::response& res, epee::json_rpc::error& error_resp);
     bool on_get_info_json(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res, epee::json_rpc::error& error_resp);
-    bool on_get_coins_json(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res, epee::json_rpc::error& error_resp);
+    bool on_get_coins_json(const COMMAND_RPC_GET_COINS::request& req, COMMAND_RPC_GET_COINS::response& res, epee::json_rpc::error& error_resp);
     bool on_hard_fork_info(const COMMAND_RPC_HARD_FORK_INFO::request& req, COMMAND_RPC_HARD_FORK_INFO::response& res, epee::json_rpc::error& error_resp);
     bool on_set_bans(const COMMAND_RPC_SETBANS::request& req, COMMAND_RPC_SETBANS::response& res, epee::json_rpc::error& error_resp);
     bool on_get_bans(const COMMAND_RPC_GETBANS::request& req, COMMAND_RPC_GETBANS::response& res, epee::json_rpc::error& error_resp);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1013,7 +1013,7 @@ namespace cryptonote
       uint64_t already_generated_coins;
 
       BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(already_generated_coins)
+        FIELDS(already_generated_coins)
       END_KV_SERIALIZE_MAP()
     };
   };

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1004,17 +1004,17 @@ namespace cryptonote
     struct request
     {
 
-      BEGIN_KV_SERIALIZE_OBJECT();
-      END_KV_SERIALIZE_OBJECT();
+      BEGIN_KV_SERIALIZE_MAP()
+      END_KV_SERIALIZE_MAP()
     };
 
     struct response
     {
       uint64_t already_generated_coins;
 
-      BEGIN_KV_SERIALIZE_OBJECT();
-        FIELDS(already_generated_coins);
-      END_KV_SERIALIZE_OBJECT();
+      BEGIN_KV_SERIALIZE_MAP()
+	KV_SERIALIZE(already_generated_coins)
+      END_KV_SERIALIZE_MAP()
     };
   };
 

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1004,8 +1004,8 @@ namespace cryptonote
     struct request
     {
 
-      BEGIN_KV_SERIALIZE_OBJECT()
-      END_KV_SERIALIZE_OBJECT()
+      BEGIN_KV_SERIALIZE_OBJECT();
+      END_KV_SERIALIZE_OBJECT();
     };
 
     struct response

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -998,6 +998,25 @@ namespace cryptonote
       END_KV_SERIALIZE_MAP()
     };
   };
+ //-----------------------------------------------
+  struct COMMAND_RPC_GET_COINS
+  {
+    struct request
+    {
+
+      BEGIN_KV_SERIALIZE_MAP()
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct response
+    {
+      uint64_t already_generated_coins;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(already_generated_coins)
+      END_KV_SERIALIZE_MAP()
+    };
+  };
 
     
   //-----------------------------------------------

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1003,7 +1003,7 @@ namespace cryptonote
   {
     struct request
     {
-
+    std::vector<uint64_t> already_generated_coins;
     BEGIN_SERIALIZE_OBJECT()
       FIELD(already_generated_coins)
     END_SERIALIZE()

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1003,16 +1003,16 @@ namespace cryptonote
   {
     struct request
     {
-     BEGIN_SERIALIZE_OBJECT()
-     END_SERIALIZE()
+     BEGIN_KV_SERIALIZE_MAP()
+     END_KV_SERIALIZE_MAP()
     };
 
     struct response
     {
-      uint64_t already_generated_coins;
-     BEGIN_SERIALIZE_OBJECT()
-       FIELD(already_generated_coins)
-     END_SERIALIZE()
+      std::vector<uint64_t> already_generated_coins;
+     BEGIN_KV_SERIALIZE_MAP()
+       KV_SERIALIZE(already_generated_coins)
+     END_KV_SERIALIZE_MAP()
     };
   };
 

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1004,8 +1004,10 @@ namespace cryptonote
     struct request
     {
 
-      BEGIN_KV_SERIALIZE_MAP()
-      END_KV_SERIALIZE_MAP()
+    BEGIN_SERIALIZE_OBJECT()
+      FIELD(already_generated_coins)
+    END_SERIALIZE()
+
     };
 
     struct response

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1004,17 +1004,17 @@ namespace cryptonote
     struct request
     {
 
-      BEGIN_SERIALIZE()
-      END_SERIALIZE()
+      BEGIN_KV_SERIALIZE_OBJECT()
+      END_KV_SERIALIZE_OBJECT()
     };
 
     struct response
     {
       uint64_t already_generated_coins;
 
-      BEGIN_SERIALIZE()
+      BEGIN_KV_SERIALIZE_OBJECT()
         FIELDS(already_generated_coins)
-      END_SERIALIZE()
+      END_KV_SERIALIZE_OBJECT()
     };
   };
 

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1009,7 +1009,7 @@ namespace cryptonote
 
     struct response
     {
-      std::vector<uint64_t> already_generated_coins;
+      uint64_t already_generated_coins;
      BEGIN_KV_SERIALIZE_MAP()
        KV_SERIALIZE(already_generated_coins)
      END_KV_SERIALIZE_MAP()

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1012,9 +1012,9 @@ namespace cryptonote
     {
       uint64_t already_generated_coins;
 
-      BEGIN_KV_SERIALIZE_OBJECT()
-        FIELDS(already_generated_coins)
-      END_KV_SERIALIZE_OBJECT()
+      BEGIN_KV_SERIALIZE_OBJECT();
+        FIELDS(already_generated_coins);
+      END_KV_SERIALIZE_OBJECT();
     };
   };
 

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1003,20 +1003,16 @@ namespace cryptonote
   {
     struct request
     {
-    std::vector<uint64_t> already_generated_coins;
-    BEGIN_SERIALIZE_OBJECT()
-      FIELD(already_generated_coins)
-    END_SERIALIZE()
-
+     BEGIN_SERIALIZE_OBJECT()
+     END_SERIALIZE()
     };
 
     struct response
     {
       uint64_t already_generated_coins;
-
-      BEGIN_KV_SERIALIZE_MAP()
-	KV_SERIALIZE(already_generated_coins)
-      END_KV_SERIALIZE_MAP()
+     BEGIN_SERIALIZE_OBJECT()
+       FIELD(already_generated_coins)
+     END_SERIALIZE()
     };
   };
 

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1004,17 +1004,17 @@ namespace cryptonote
     struct request
     {
 
-      BEGIN_KV_SERIALIZE_MAP()
-      END_KV_SERIALIZE_MAP()
+      BEGIN_SERIALIZE()
+      END_SERIALIZE()
     };
 
     struct response
     {
       uint64_t already_generated_coins;
 
-      BEGIN_KV_SERIALIZE_MAP()
+      BEGIN_SERIALIZE()
         FIELDS(already_generated_coins)
-      END_KV_SERIALIZE_MAP()
+      END_SERIALIZE()
     };
   };
 


### PR DESCRIPTION
Still working on the output, CMC requested already_generated_coins in it's own object