### PR TITLE
build: fix gcc false positive 'stringop-overflow' warning ref: xmr#4476

### DIFF
--- a/src/cryptonote_core/cryptonote_tx_utils.cpp
+++ b/src/cryptonote_core/cryptonote_tx_utils.cpp
@@ -127,7 +127,7 @@ namespace cryptonote
         out_amounts[1] += out_amounts[0];
         for (size_t n = 1; n < out_amounts.size(); ++n)
           out_amounts[n - 1] = out_amounts[n];
-        out_amounts.resize(out_amounts.size() - 1);
+        out_amounts.pop_back();
       }
     }
     else


### PR DESCRIPTION
[credits: xiphon](https://github.com/monero-project/monero/pull/4476/files#diff-6d5dd4fd9a453fe74c92e7fedada9ea4R130)